### PR TITLE
does not use custom package URLs in SetupDevEnv.jl after PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,9 +12,16 @@ unit_tests_julia1.9:
     - cd ${CI_PROJECT_DIR}
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
-    - julia --project=. ${CI_PROJECT_DIR}/ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml
+    - >
+      if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
+        # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit
+        julia --project=. ${CI_PROJECT_DIR}/ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml NO_MESSAGE
+      else
+        julia --project=. ${CI_PROJECT_DIR}/ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml
+      fi
     - julia --project=. -e 'import Pkg; Pkg.instantiate()'
     - julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'
+  interruptible: true
   tags:
     - cpuonly
 
@@ -22,6 +29,13 @@ verify-unit-test-deps_julia1.9:
   image: julia:1.9
   stage: verify-unit-test-deps
   script:
-    - julia --color=yes ${CI_PROJECT_DIR}/ci/verify_env.jl
+    - >
+      if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
+        # does not check for custom package URLs on the main and dev branch
+        echo "no custom package URL check necessary"
+      else
+        julia ${CI_PROJECT_DIR}/ci/verify_env.jl
+      fi
+  interruptible: true
   tags:
     - cpuonly

--- a/ci/SetupDevEnv/src/SetupDevEnv.jl
+++ b/ci/SetupDevEnv/src/SetupDevEnv.jl
@@ -90,7 +90,13 @@ if abspath(PROGRAM_FILE) == @__FILE__
     end
 
     project_toml_path = ARGS[1]
-    extract_env_vars_from_git_message!()
+
+    # custom commit message variable can be set as second argument
+    if length(ARGS) < 2
+        extract_env_vars_from_git_message!()
+    else
+        extract_env_vars_from_git_message!(ARGS[2])
+    end
     # get only dependencies, which starts with QED
     deps = get_dependencies(project_toml_path, r"(QED)")
     add_develop_dep(deps)


### PR DESCRIPTION
After PR #3 I recognized, that lines starting with `CI_UNIT_PKG_URL_` exist in the commit message of the merge request. This triggers accidentally custom URLs for packages in the `SetupDevEnv.jl` script. Because it does not make any sense to use custom URLs on the `main` and `dev` branch, this PR disable the feature for this branches.

Add also gitlab CI attribute `interruptible: true` that CI can be aborted if a new commit was pushed to the same branch.