### PR TITLE
Hotfix: run integ tests in production

### DIFF
--- a/.ci/integTestGen/src/integTestGen.jl
+++ b/.ci/integTestGen/src/integTestGen.jl
@@ -307,7 +307,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     # the script is locate in ci/integTestGen/src
     # so we need to go 3 steps upwards in hierarchy to get the QED.jl Project.toml
     create_working_env(abspath(joinpath((@__DIR__), "../../..")), package_infos)
-    depending_pkg = depending_projects(modified_pkg, keys(package_infos))
+  depending_pkg = depending_projects(modified_pkg, collect(keys(package_infos)))
 
     job_yaml = Dict()
 

--- a/.ci/integTestGen/src/integTestGen.jl
+++ b/.ci/integTestGen/src/integTestGen.jl
@@ -307,7 +307,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     # the script is locate in ci/integTestGen/src
     # so we need to go 3 steps upwards in hierarchy to get the QED.jl Project.toml
     create_working_env(abspath(joinpath((@__DIR__), "../../..")), package_infos)
-  depending_pkg = depending_projects(modified_pkg, collect(keys(package_infos)))
+    depending_pkg = depending_projects(modified_pkg, collect(keys(package_infos)))
 
     job_yaml = Dict()
 


### PR DESCRIPTION
This should finally fix #30 

## Explanation

Since the last change in #31, the run part also needs to be updated. The function `depending_projects` does not consume `KeySets` anymore. 