### PR TITLE
add script, which set QED dependencies of QED dependencies to the development version in integration tests

### DIFF
--- a/.ci/integTestGen/Project.toml
+++ b/.ci/integTestGen/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PkgDependency = "9eb5382b-762c-48ca-8139-e736883fe800"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"

--- a/.ci/integTestGen/README.md
+++ b/.ci/integTestGen/README.md
@@ -15,3 +15,5 @@ You can set the environment variables in two different ways:
 ## Optional Environment Variables
 
 By default, if an integration test is generated it clones the develop branch of the upstream project. The clone can be overwritten by the environment variable `CI_INTG_PKG_URL_<dep_name>=https://url/to/the/repository#<commit_hash>`. You can find all available environment variables in the dictionary `package_infos` in the `integTestGen.jl`.
+
+Set the environment variable `CI_COMMIT_REF_NAME` to determine the target branch of a GitHub pull request. The form must be `CI_COMMIT_REF_NAME=pr-<PR number>/<repo owner of source branch>/<project name>/<source branch name>`. Here is an example: `CI_COMMIT_REF_NAME=pr-41/SimeonEhrig/QED.jl/setDevDepDeps`. If the environment variable is not set, the default target branch `dev` is used.


### PR DESCRIPTION
As soon the PR is merged, other QED projects needs to rerun the CI pipeline to use the function.

fix #36 