### PR TITLE
Hotfix/compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,15 +4,16 @@ authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus 
 version = "0.1.0"
 
 [deps]
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
 QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
 QEDevents = "fc3ce04a-5be5-4f3a-acff-eceaab723759"
 QEDfields = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
 QEDprocesses = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
-Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 julia = "1.6"
+Reexport = "^1.2"
 QEDbase = "0.2.2"
 QEDcore = "0.1"
 QEDevents = "0.1"


### PR DESCRIPTION
This fixes the reexport.jl compat entry. It is now the same as in QEDcore, which is already registered, so this should work.

Merge to main: Do not squash