### PR TITLE
fix integration test for merge in the main branch

### DIFF
--- a/.ci/integTestGen/test/Project.toml
+++ b/.ci/integTestGen/test/Project.toml
@@ -2,3 +2,4 @@
 PkgDependency = "9eb5382b-762c-48ca-8139-e736883fe800"
 Term = "22787eb5-b846-44ae-b979-8e399b8463ab"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"

--- a/.ci/integTestGen/test/generate_job_yaml.jl
+++ b/.ci/integTestGen/test/generate_job_yaml.jl
@@ -1,0 +1,197 @@
+using YAML
+
+"""
+    yaml_diff(given, expected)::AbstractString
+
+Generates an error string that shows a given and an expected data structure in yaml 
+representation.
+
+# Returns
+- Human readable error message for the comparison of two job yaml's.
+"""
+function yaml_diff(given, expected)::AbstractString
+    output = "\ngiven:\n"
+    output *= String(YAML.yaml(given))
+    output *= "\nexpected:\n"
+    output *= String(YAML.yaml(expected))
+    return output
+end
+
+@testset "generate_job_yaml()" begin
+    package_infos = integTestGen.get_package_info()
+
+    @testset "target main branch, no PR" begin
+        job_yaml = Dict()
+        integTestGen.generate_job_yaml!(
+            "QEDcore", "main", "/path/to/QEDcore.jl", job_yaml, package_infos
+        )
+        @test length(job_yaml) == 1
+
+        expected_job_yaml = Dict()
+        expected_job_yaml["IntegrationTestQEDcore"] = Dict(
+            "image" => "julia:1.9",
+            "interruptible" => true,
+            "tags" => ["cpuonly"],
+            "script" => [
+                "apt update",
+                "apt install -y git",
+                "cd /",
+                "git clone -b main $(package_infos["QEDcore"].url) integration_test",
+                "cd integration_test",
+                "julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url=\"https://github.com/QEDjl-project/registry.git\"));'",
+                "julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url=\"https://github.com/JuliaRegistries/General\"));'",
+                "julia --project=. -e 'import Pkg; Pkg.develop(path=\"/path/to/QEDcore.jl\");'",
+                "julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'",
+            ],
+        )
+
+        @test (
+            @assert job_yaml["IntegrationTestQEDcore"]["script"] ==
+                expected_job_yaml["IntegrationTestQEDcore"]["script"] yaml_diff(
+                job_yaml["IntegrationTestQEDcore"]["script"],
+                expected_job_yaml["IntegrationTestQEDcore"]["script"],
+            );
+            true
+        )
+
+        @test (
+            @assert job_yaml["IntegrationTestQEDcore"] ==
+                expected_job_yaml["IntegrationTestQEDcore"] yaml_diff(
+                job_yaml["IntegrationTestQEDcore"],
+                expected_job_yaml["IntegrationTestQEDcore"],
+            );
+            true
+        )
+    end
+
+    @testset "target non main branch, if PR or not is the same" begin
+        job_yaml = Dict()
+        integTestGen.generate_job_yaml!(
+            "QEDcore", "feature3", "/path/to/QEDcore.jl", job_yaml, package_infos
+        )
+        @test length(job_yaml) == 1
+
+        expected_job_yaml = Dict()
+        expected_job_yaml["IntegrationTestQEDcore"] = Dict(
+            "image" => "julia:1.9",
+            "interruptible" => true,
+            "tags" => ["cpuonly"],
+            "script" => [
+                "apt update",
+                "apt install -y git",
+                "cd /",
+                "git clone -b feature3 $(package_infos["QEDcore"].url) integration_test",
+                "git clone -b dev https://github.com/QEDjl-project/QED.jl.git /integration_test_tools",
+                "cd integration_test",
+                "julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url=\"https://github.com/QEDjl-project/registry.git\"));'",
+                "julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url=\"https://github.com/JuliaRegistries/General\"));'",
+                "julia --project=. -e 'import Pkg; Pkg.develop(path=\"/path/to/QEDcore.jl\");'",
+                "julia --project=. /integration_test_tools/.ci/set_dev_dependencies.jl",
+                "julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'",
+            ],
+        )
+
+        @test (
+            @assert job_yaml["IntegrationTestQEDcore"]["script"] ==
+                expected_job_yaml["IntegrationTestQEDcore"]["script"] yaml_diff(
+                job_yaml["IntegrationTestQEDcore"]["script"],
+                expected_job_yaml["IntegrationTestQEDcore"]["script"],
+            );
+            true
+        )
+
+        @test (
+            @assert job_yaml["IntegrationTestQEDcore"] ==
+                expected_job_yaml["IntegrationTestQEDcore"] yaml_diff(
+                job_yaml["IntegrationTestQEDcore"],
+                expected_job_yaml["IntegrationTestQEDcore"],
+            );
+            true
+        )
+    end
+
+    @testset "target main branch, PR" begin
+        job_yaml = Dict()
+        integTestGen.generate_job_yaml!(
+            "QEDcore", "dev", "/path/to/QEDcore.jl", job_yaml, package_infos
+        )
+        integTestGen.generate_job_yaml!(
+            "QEDcore", "main", "/path/to/QEDcore.jl", job_yaml, package_infos, true
+        )
+        @test length(job_yaml) == 2
+
+        expected_job_yaml = Dict()
+        expected_job_yaml["IntegrationTestQEDcore"] = Dict(
+            "image" => "julia:1.9",
+            "interruptible" => true,
+            "tags" => ["cpuonly"],
+            "script" => [
+                "apt update",
+                "apt install -y git",
+                "cd /",
+                "git clone -b dev $(package_infos["QEDcore"].url) integration_test",
+                "git clone -b dev https://github.com/QEDjl-project/QED.jl.git /integration_test_tools",
+                "cd integration_test",
+                "julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url=\"https://github.com/QEDjl-project/registry.git\"));'",
+                "julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url=\"https://github.com/JuliaRegistries/General\"));'",
+                "julia --project=. -e 'import Pkg; Pkg.develop(path=\"/path/to/QEDcore.jl\");'",
+                "julia --project=. /integration_test_tools/.ci/set_dev_dependencies.jl",
+                "julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'",
+            ],
+        )
+
+        @test (
+            @assert job_yaml["IntegrationTestQEDcore"]["script"] ==
+                expected_job_yaml["IntegrationTestQEDcore"]["script"] yaml_diff(
+                job_yaml["IntegrationTestQEDcore"]["script"],
+                expected_job_yaml["IntegrationTestQEDcore"]["script"],
+            );
+            true
+        )
+
+        @test (
+            @assert job_yaml["IntegrationTestQEDcore"] ==
+                expected_job_yaml["IntegrationTestQEDcore"] yaml_diff(
+                job_yaml["IntegrationTestQEDcore"],
+                expected_job_yaml["IntegrationTestQEDcore"],
+            );
+            true
+        )
+
+        expected_job_yaml["IntegrationTestQEDcoreReleaseTest"] = Dict(
+            "image" => "julia:1.9",
+            "interruptible" => true,
+            "tags" => ["cpuonly"],
+            "allow_failure" => true,
+            "script" => [
+                "apt update",
+                "apt install -y git",
+                "cd /",
+                "git clone -b main $(package_infos["QEDcore"].url) integration_test",
+                "cd integration_test",
+                "julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url=\"https://github.com/QEDjl-project/registry.git\"));'",
+                "julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url=\"https://github.com/JuliaRegistries/General\"));'",
+                "julia --project=. -e 'import Pkg; Pkg.develop(path=\"/path/to/QEDcore.jl\");'",
+                "julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'",
+            ],
+        )
+
+        @test (
+            @assert job_yaml["IntegrationTestQEDcoreReleaseTest"]["script"] ==
+                expected_job_yaml["IntegrationTestQEDcoreReleaseTest"]["script"] yaml_diff(
+                job_yaml["IntegrationTestQEDcoreReleaseTest"]["script"],
+                expected_job_yaml["IntegrationTestQEDcoreReleaseTest"]["script"],
+            );
+            true
+        )
+
+        @test (
+            @assert job_yaml["IntegrationTestQEDcoreReleaseTest"] ==
+                expected_job_yaml["IntegrationTestQEDcoreReleaseTest"] yaml_diff(
+                job_yaml["IntegrationTestQEDcoreReleaseTest"],
+                expected_job_yaml["IntegrationTestQEDcoreReleaseTest"],
+            );
+            true
+        )
+    end
+end

--- a/.ci/integTestGen/test/runtests.jl
+++ b/.ci/integTestGen/test/runtests.jl
@@ -3,3 +3,4 @@ using Test
 
 include("./integTestGen.jl")
 include("./get_target_branch.jl")
+include("./generate_job_yaml.jl")


### PR DESCRIPTION
If we want to merge in the main branch, we do it because we want to publish the package. Therefore, we need to be sure that there is an existing version of the dependent QED packages that works with the new version of the package we want to release. The integration tests are tested against the development branch and the release version.
- The dev branch version must pass, as this means that the latest version of the other QED packages is compatible with our release version.
- The release version can exist. If they exist, it means that we do not need to release a new version of this package.

I will open an test PR to test if the feature is correctly working. If it is working, I mark the PR for ready for review.