### PR TITLE
Bootloader.jl: allow to set if generate jobs for a pull request via script argument

### DIFF
--- a/.ci/CI/src/Bootloader.jl
+++ b/.ci/CI/src/Bootloader.jl
@@ -53,12 +53,18 @@ function main()
     package_path = get_project_path(args)
     test_package = get_package_name_version(package_path)
 
+    if "--pr" in ARGS && "--no-pr" in ARGS
+        throw(ErrorException("It is not allowed to set the arguments --pr and --no-pr at the same time."))
+    end
+
     # TOOD: move detecting if is a pull request from environment variable CI_COMMIT_REF_NAME
     # in an extra script
-    # Workaround: check if environment variable `--pr` is set to override environment variable
+    # Workaround: check if environment variable `--pr` or `--no-pr` is set to override environment variable
     # CI_COMMIT_REF_NAME
     if "--pr" in ARGS
-        pull_request = args["pr"]
+        pull_request = true
+    elseif "--no-pr" in ARGS
+        pull_request = false
     else
         pull_request = is_pull_request(get(ENV, "CI_COMMIT_REF_NAME", ""))
     end

--- a/.ci/CI/src/Bootloader.jl
+++ b/.ci/CI/src/Bootloader.jl
@@ -52,7 +52,16 @@ function main()
     setup_dev_env::Bool = target_branch != "main"
     package_path = get_project_path(args)
     test_package = get_package_name_version(package_path)
-    pull_request = is_pull_request(get(ENV, "CI_COMMIT_REF_NAME", ""))
+
+    # TOOD: move detecting if is a pull request from environment variable CI_COMMIT_REF_NAME
+    # in an extra script
+    # Workaround: check if environment variable `--pr` is set to override environment variable
+    # CI_COMMIT_REF_NAME
+    if "--pr" in ARGS
+        pull_request = args["pr"]
+    else
+        pull_request = is_pull_request(get(ENV, "CI_COMMIT_REF_NAME", ""))
+    end
 
     @info "Test package name: $(test_package.name)"
     @info "Test package version: $(test_package.version)"

--- a/.ci/CI/src/modules/Bootloader/Arguments.jl
+++ b/.ci/CI/src/modules/Bootloader/Arguments.jl
@@ -75,7 +75,10 @@ function parse_commandline()::Dict{String, Any}
         help = "If target branch is set, does not read the target branch from a GitHub Pull Request which is set via environment variable `CI_COMMIT_REF_NAME`."
         arg_type = String
         "--pr"
-        help = "Generate jobs for a pull request."
+        help = "Generate jobs for a pull request. If not set, the value of the environment variable CI_COMMIT_REF_NAME decides if it is pull request or not."
+        action = :store_true
+        "--no-pr"
+        help = "Generate jobs for a normal commit. If not set, the value of the environment variable CI_COMMIT_REF_NAME decides if it is pull request or not."
         action = :store_true
         "--project-path"
         help = "Set the path to the package folder of the package to be tested. Can also be set via the environment variable `CI_PROJECT_DIR`."

--- a/.ci/CI/src/modules/Bootloader/Arguments.jl
+++ b/.ci/CI/src/modules/Bootloader/Arguments.jl
@@ -74,6 +74,9 @@ function parse_commandline()::Dict{String, Any}
         "--target-branch"
         help = "If target branch is set, does not read the target branch from a GitHub Pull Request which is set via environment variable `CI_COMMIT_REF_NAME`."
         arg_type = String
+        "--pr"
+        help = "Generate jobs for a pull request."
+        action = :store_true
         "--project-path"
         help = "Set the path to the package folder of the package to be tested. Can also be set via the environment variable `CI_PROJECT_DIR`."
         arg_type = String

--- a/.ci/bootloader_integration_tests.yml
+++ b/.ci/bootloader_integration_tests.yml
@@ -1,0 +1,170 @@
+# Test case 1: target branch dev, no pull request
+.bootloader_jl_test_1: &bootloader_jl_test_1
+    - mkdir -p output/test1
+    - julia --project=. src/Bootloader.jl
+      --project-path ../../QEDcore
+      --target-branch dev
+      --cuda --amdgpu > output/test1/out.yaml
+    #    Unit tests are generated
+    - grep -q output/test1/out.yaml -e unit_test
+    #    Integration tests are generated
+    - grep -q output/test1/out.yaml -e integration_test
+    #    GPU tests are generated
+    - grep output/test1/out.yaml -e unit_test | grep -q -e cuda
+    - grep output/test1/out.yaml -e unit_test | grep -q -e amdgpu
+    - grep output/test1/out.yaml -e integration_test | grep -q -e cuda
+    - grep output/test1/out.yaml -e integration_test | grep -q -e amdgpu
+    #    check if VerifyEnv.jl is used
+    - grep -q output/test1/out.yaml -e "VerifyEnv.jl"
+
+# Test case 2: target branch dev, pull request
+.bootloader_jl_test_2: &bootloader_jl_test_2
+    - mkdir -p output/test2
+    - julia --project=. src/Bootloader.jl
+      --project-path ../../QEDcore
+      --target-branch dev
+      --pr
+      --cuda --amdgpu > output/test2/out.yaml
+    #    Unit tests are generated
+    - grep -q output/test2/out.yaml -e unit_test
+    #    Integration tests are generated
+    #    TODO: if issue #102 is solved, no integration test should be generated
+    - grep -q output/test2/out.yaml -e integration_test
+    #    GPU tests are generated
+    - grep output/test2/out.yaml -e unit_test | grep -q -e cuda
+    - grep output/test2/out.yaml -e unit_test | grep -q -e amdgpu
+    - grep output/test2/out.yaml -e integration_test | grep -q -e cuda
+    - grep output/test2/out.yaml -e integration_test | grep -q -e amdgpu
+    #    check if VerifyEnv.jl is used
+    - grep -q output/test2/out.yaml -e "VerifyEnv.jl"
+
+# Test case 3: target branch main, no pull request
+.bootloader_jl_test_3: &bootloader_jl_test_3
+    - mkdir -p output/test3
+    - julia --project=. src/Bootloader.jl
+      --project-path ../../QEDcore
+      --target-branch main
+      --cuda --amdgpu
+      --output-cpu=output/test3/cpu.yaml
+      --output-gpu=output/test3/gpu.yaml
+      --output-unit-test-verify=output/test3/verify.yaml
+    #    Unit tests are generated
+    - grep -q output/test3/cpu.yaml -e unit_test
+    - grep -q output/test3/gpu.yaml -e unit_test
+    #    Integration tests are generated
+    #    TODO: if issue #102 is solved, no integration test should be generated
+    - grep -q output/test3/cpu.yaml -e integration_test
+    - |-
+      [ $(grep output/test3/cpu.yaml -e ^integration_test | grep -c "_release_test") -eq 0 ]
+    - grep -q output/test3/gpu.yaml -e integration_test
+    - |-
+      [ $(grep output/test3/gpu.yaml -e ^integration_test | grep -c "_release_test") -eq 0 ]
+    #    GPU tests are generated
+    - grep output/test3/gpu.yaml -e unit_test | grep -q -e cuda
+    - grep output/test3/gpu.yaml -e unit_test | grep -q -e amdgpu
+    - |-
+      [ $(grep output/test3/cpu.yaml -e ^unit_test | grep -c "amdgpu") -eq 0 ]
+    - grep output/test3/gpu.yaml -e integration_test | grep -q -e cuda
+    - grep output/test3/gpu.yaml -e integration_test | grep -q -e amdgpu
+    - |-
+      [ $(grep output/test3/cpu.yaml -e ^integration_test | grep -c "cuda") -eq 0 ]
+    #    check if VerifyEnv.jl is not used
+    - |-
+      [ $(grep output/test3/verify.yaml -c -e VerifyEnv.jl) -eq 0 ]
+
+# Test case 4: target branch main, pull request
+.bootloader_jl_test_4: &bootloader_jl_test_4
+    - mkdir -p output/test4
+    - julia --project=. src/Bootloader.jl
+      --project-path ../../QEDcore
+      --target-branch main
+      --pr
+      --cuda --amdgpu
+      --output-cpu=output/test4/cpu.yaml
+      --output-gpu=output/test4/gpu.yaml
+      --output-unit-test-verify=output/test4/verify.yaml
+    #    Unit tests are generated
+    - grep -q output/test4/cpu.yaml -e unit_test
+    - grep -q output/test4/gpu.yaml -e unit_test
+    #    Integration tests are generated
+    #    Check also if integration tests against the released versions are generated
+    - grep -q output/test4/cpu.yaml -e integration_test
+    - grep output/test4/cpu.yaml -e ^integration_test | grep -q "_release_test"
+    - grep -q output/test4/gpu.yaml -e integration_test
+    - grep output/test4/gpu.yaml -e ^integration_test | grep -q "_release_test"
+    #    GPU tests are generated
+    - grep output/test4/gpu.yaml -e unit_test | grep -q -e cuda
+    - grep output/test4/gpu.yaml -e unit_test | grep -q -e amdgpu
+    - |-
+      [ $(grep output/test4/cpu.yaml -e ^unit_test | grep -c "amdgpu") -eq 0 ]
+    - grep output/test4/gpu.yaml -e integration_test | grep -q -e cuda
+    - grep output/test4/gpu.yaml -e integration_test | grep -q -e amdgpu
+    - |-
+      [ $(grep output/test4/cpu.yaml -e ^integration_test | grep -c "cuda") -eq 0 ]
+    #    check if VerifyEnv.jl is not used
+    - |-
+      [ $(grep output/test4/verify.yaml -c -e VerifyEnv.jl) -eq 0 ]
+
+# Test case 5: target branch dev, pull request, no integration test
+# depending on is pull request or not, the NO_MESSAGE flag is set for unit tests
+# make it testable via grep, disable integration tests
+.bootloader_jl_test_5: &bootloader_jl_test_5
+    - mkdir -p output/test5
+    - julia --project=. src/Bootloader.jl
+      --project-path ../../QEDcore
+      --target-branch dev
+      --pr
+      --nointeg
+      --output-cpu=output/test5/cpu.yaml
+      --output-unit-test-verify=output/test5/verify.yaml
+    #    Unit tests are generated
+    - grep -q output/test5/cpu.yaml -e unit_test
+    #    Integration tests should not be generated
+    - |-
+      [ $(grep output/test5/cpu.yaml -c -e ^integration_test) -eq 0 ]
+    # NO_MESSAGE Flag is set
+    - |-
+      [ $(grep output/test5/cpu.yaml -e ^integration_test | grep -c NO_MESSAGE) -eq 0 ]
+    #    check if VerifyEnv.jl is not used
+    - grep -q output/test5/verify.yaml -e "VerifyEnv.jl"
+
+# Test case 6: target branch main, pull request, no integration test
+# depending on is pull request or not, the NO_MESSAGE flag is set for unit tests
+# make it testable via grep, disable integration tests
+.bootloader_jl_test_6: &bootloader_jl_test_6
+    - mkdir -p output/test6
+    - julia --project=. src/Bootloader.jl
+      --project-path ../../QEDcore
+      --target-branch main
+      --pr
+      --nointeg
+      --output-cpu=output/test6/cpu.yaml
+      --output-unit-test-verify=output/test6/verify.yaml
+    #    Unit tests are generated
+    - grep -q output/test6/cpu.yaml -e unit_test
+    #    Integration tests should not be generated
+    - |-
+      [ $(grep output/test6/cpu.yaml -c -e ^integration_test) -eq 0 ]
+    # NO_MESSAGE Flag is set
+    - grep output/test6/cpu.yaml -e "SetupDevEnv.jl" | grep -q NO_MESSAGE
+    #    check if VerifyEnv.jl is not used
+    - |-
+      [ $(grep output/test6/verify.yaml -c -e VerifyEnv.jl) -eq 0 ]
+
+bootloader_jl_integration_test:
+  image: julia:1.10
+  stage: integration-test
+  script:
+    - apt update && apt install -y git
+    - git clone --depth 1 -b dev https://github.com/QEDjl-project/QEDcore.jl.git QEDcore
+    - cd ${CI_PROJECT_DIR}/.ci/CI/
+    - julia --project=. -e 'import Pkg; Pkg.instantiate()'
+    - *bootloader_jl_test_1
+    - *bootloader_jl_test_2
+    - *bootloader_jl_test_3
+    - *bootloader_jl_test_4
+    - *bootloader_jl_test_5
+    - *bootloader_jl_test_6
+  interruptible: true
+  tags:
+    - cpuonly

--- a/.ci/bootloader_integration_tests.yml
+++ b/.ci/bootloader_integration_tests.yml
@@ -4,6 +4,7 @@
     - julia --project=. src/Bootloader.jl
       --project-path ../../QEDcore
       --target-branch dev
+      --no-pr
       --cuda --amdgpu > output/test1/out.yaml
     #    Unit tests are generated
     - grep -q output/test1/out.yaml -e unit_test
@@ -44,6 +45,7 @@
     - julia --project=. src/Bootloader.jl
       --project-path ../../QEDcore
       --target-branch main
+      --no-pr
       --cuda --amdgpu
       --output-cpu=output/test3/cpu.yaml
       --output-gpu=output/test3/gpu.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,9 @@
 stages:
   - unit-test
+  - integration-test
   - verify-unit-test-deps
+
+include: .ci/bootloader_integration_tests.yml
 
 .untit_test_template:
   stage: unit-test


### PR DESCRIPTION
Makes easier to test Bootloader.jl functionality. Add command line arguments to configure `Bootloader.jl` to generate CI jobs for a pull request or normal commit. Allows to implement some integration tests for `Bootloader.jl`.

Preparation for issue #123

- [x] implement `Bootloader.jl` CI integration tests 