### PR TITLE
use QEDCore package to verify Bootloader.jl code in the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - unit-test
   - integration-test
+  - qedcore-integration-test
   - verify-unit-test-deps
 
 include: .ci/bootloader_integration_tests.yml
@@ -87,3 +88,16 @@ verify-unit-test-deps:
   interruptible: true
   tags:
     - cpuonly
+
+trigger_job:
+  stage: qedcore-integration-test
+  variables:
+    # use Bootloader.jl code of the pull request
+    CI_GIT_CI_TOOLS_URL: "${CI_PROJECT_URL}.git"
+    CI_GIT_CI_TOOLS_BRANCH: $CI_COMMIT_REF_NAME
+  trigger:
+    project: hzdr/qedjl-project/qedcore.jl
+    strategy: depend
+  # run only in pull requests
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^pr-*./


### PR DESCRIPTION
Triggers automatically the CI of the QEDCore.jl project with modified code of Bootloader.jl as part of the CI in a pull request.
Replace the need to create test PRs in other projects, like this PR: https://github.com/QEDjl-project/QEDcore.jl/pull/114 

Note: I tested with a direct push to GitLab.com that the job is note executed if we are not in GitHub pull request. Still there is a chance, that I did something wrong. I use the feature for the fist time. So we will see if it really works after merging.