### PR TITLE
Bootloader.jl: use multiple dispatch for the platform argument for generating unit and integration tests

### DIFF
--- a/.ci/CI/src/Bootloader.jl
+++ b/.ci/CI/src/Bootloader.jl
@@ -143,11 +143,11 @@ function main()
 
             julia_version_prefix = "_" * replace(julia_version_type_name.version, "." => "_")
 
-            if platform == CUDA
+            if platform == CUDA()
                 julia_version_prefix = "_cuda" * julia_version_prefix
             end
 
-            if platform == AMDGPU
+            if platform == AMDGPU()
                 julia_version_prefix = "_amdgpu" * julia_version_prefix
             end
 

--- a/.ci/CI/src/modules/Bootloader/Arguments.jl
+++ b/.ci/CI/src/modules/Bootloader/Arguments.jl
@@ -39,9 +39,9 @@ function get_output_job_yaml(job_yaml::Dict, platform::TestPlatform)::Dict
         throw(ErrorException("job_yamls has no key stdout"))
     end
 
-    if platform == CPU
+    if platform == CPU()
         return get(job_yaml, "output-cpu", job_yaml["stdout"])
-    elseif (platform == CUDA || platform == AMDGPU)
+    elseif (platform == CUDA() || platform == AMDGPU())
         return get(job_yaml, "output-gpu", job_yaml["stdout"])
     else
         throw(ErrorException("Unknown platform: $(platform)"))

--- a/.ci/CI/src/modules/Bootloader/JobConfig.jl
+++ b/.ci/CI/src/modules/Bootloader/JobConfig.jl
@@ -11,7 +11,7 @@ function get_unit_test_configs(args::Dict{String, Any})::Vector{Tuple{JuliaVersi
                 unit_test_types,
                 (
                     Nightly(get_unit_test_nightly_baseimage()),
-                    CPU,
+                    CPU(),
                 )
             )
 
@@ -20,7 +20,7 @@ function get_unit_test_configs(args::Dict{String, Any})::Vector{Tuple{JuliaVersi
                 unit_test_types,
                 (
                     ReleaseCandidate(),
-                    CPU,
+                    CPU(),
                 )
             )
             continue
@@ -31,7 +31,7 @@ function get_unit_test_configs(args::Dict{String, Any})::Vector{Tuple{JuliaVersi
                     unit_test_types,
                     (
                         ReleaseVersion(julia_version),
-                        CPU,
+                        CPU(),
                     )
                 )
             end
@@ -41,7 +41,7 @@ function get_unit_test_configs(args::Dict{String, Any})::Vector{Tuple{JuliaVersi
                     unit_test_types,
                     (
                         ReleaseVersion(julia_version),
-                        CUDA,
+                        CUDA(),
                     )
                 )
             end
@@ -51,7 +51,7 @@ function get_unit_test_configs(args::Dict{String, Any})::Vector{Tuple{JuliaVersi
                     unit_test_types,
                     (
                         ReleaseVersion(julia_version),
-                        AMDGPU,
+                        AMDGPU(),
                     )
                 )
             end
@@ -88,7 +88,7 @@ function get_integration_test_configs(
                 integ_test_types,
                 (
                     ReleaseVersion(julia_version),
-                    CPU,
+                    CPU(),
                 )
             )
         end
@@ -98,7 +98,7 @@ function get_integration_test_configs(
                 integ_test_types,
                 (
                     ReleaseVersion(julia_version),
-                    CUDA,
+                    CUDA(),
                 )
             )
         end
@@ -108,7 +108,7 @@ function get_integration_test_configs(
                 integ_test_types,
                 (
                     ReleaseVersion(julia_version),
-                    AMDGPU,
+                    AMDGPU(),
                 )
             )
         end

--- a/.ci/CI/src/modules/GenericTest/TestType.jl
+++ b/.ci/CI/src/modules/GenericTest/TestType.jl
@@ -42,7 +42,25 @@ Base.show(io::IO, obj::TestType) = print(io, get_test_type_name(obj))
 """
 Specify target processor for the tests.
 """
-@enum TestPlatform CPU CUDA AMDGPU ONEAPI METAL
+abstract type TestPlatform end
+struct CPU <: TestPlatform end
+struct CUDA <: TestPlatform end
+struct AMDGPU <: TestPlatform end
+struct ONEAPI <: TestPlatform end
+struct METAL <: TestPlatform end
+
+TestPlatforms = [CPU(), CUDA(), AMDGPU(), ONEAPI(), METAL()]
+
+"""
+Get string representation
+"""
+function get_platform_name(::Type{T}) where {T <: TestPlatform}
+    return string(nameof(T))
+end
+
+function get_platform_name(::T) where {T <: TestPlatform}
+    return get_platform_name(T)
+end
 
 abstract type JuliaVersionType end
 

--- a/.ci/CI/src/modules/IntegTest/TestJob.jl
+++ b/.ci/CI/src/modules/IntegTest/TestJob.jl
@@ -26,7 +26,7 @@ generated job contains all properties to be directly translated to GitLab CI yam
 - `test_package::TestPackage`: Properties of the package to be tested, such as name and version.
 - `setup_dev_env::Bool`: If the value is true, additional job code is generated that allows the dev
     or feature branch versions of the QED dependencies to be used.
-- `setup_dev_env::Bool`: If the value is true, add GitLab CI flag `allow_failure: true`.
+- `can_fail::Bool`: If the value is true, add GitLab CI flag `allow_failure: true`.
 - `integration_test_name::AbstractString`: Name of the integration test.
 - `integration_test_repo::GitRepoAddress`: Git repository URL and branch of the package used for
     the integration test.
@@ -46,17 +46,122 @@ function add_integration_test_job_yaml!(
         integration_test_name::AbstractString,
         integration_test_repo::GitRepoAddress,
         integration_test_type::ReleaseVersion,
-        test_platform::TestPlatform = CPU,
+        test_platform::CPU,
         tools_git_repo::GitRepoAddress = GitRepoAddress(
             "https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git", "dev"
         )
     )
-    if test_platform in [ONEAPI, METAL]
-        throw(ArgumentError("argument test_platform not implemented for $(test_platform)"))
-    end
-
     _add_stage_once!(job_dict, "integ-test")
 
+    job_yaml = _get_normal_unit_test(
+        test_package,
+        setup_dev_env,
+        can_fail,
+        integration_test_repo,
+        integration_test_type,
+        tools_git_repo
+    )
+    job_yaml["tags"] = ["cpuonly"]
+
+    job_dict["integration_test_$(integration_test_name)"] = job_yaml
+    return nothing
+end
+
+function add_integration_test_job_yaml!(
+        job_dict::Dict,
+        test_package::TestPackage,
+        setup_dev_env::Bool,
+        can_fail::Bool,
+        integration_test_name::AbstractString,
+        integration_test_repo::GitRepoAddress,
+        integration_test_type::ReleaseVersion,
+        test_platform::CUDA,
+        tools_git_repo::GitRepoAddress = GitRepoAddress(
+            "https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git", "dev"
+        )
+    )
+    _add_stage_once!(job_dict, "integ-test")
+
+    job_yaml = _get_normal_unit_test(
+        test_package,
+        setup_dev_env,
+        can_fail,
+        integration_test_repo,
+        integration_test_type,
+        tools_git_repo
+    )
+    job_yaml["tags"] = ["cuda", "x86_64"]
+
+    job_dict["integration_test_$(integration_test_name)"] = job_yaml
+    return nothing
+end
+
+function add_integration_test_job_yaml!(
+        job_dict::Dict,
+        test_package::TestPackage,
+        setup_dev_env::Bool,
+        can_fail::Bool,
+        integration_test_name::AbstractString,
+        integration_test_repo::GitRepoAddress,
+        integration_test_type::ReleaseVersion,
+        test_platform::AMDGPU,
+        tools_git_repo::GitRepoAddress = GitRepoAddress(
+            "https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git", "dev"
+        )
+    )
+    _add_stage_once!(job_dict, "integ-test")
+
+    job_yaml = _get_normal_unit_test(
+        test_package,
+        setup_dev_env,
+        can_fail,
+        integration_test_repo,
+        integration_test_type,
+        tools_git_repo
+    )
+    _add_julia_rocm_environment!(job_yaml, integration_test_type)
+    job_yaml["tags"] = ["rocm", "x86_64"]
+
+
+    job_dict["integration_test_$(integration_test_name)"] = job_yaml
+    return nothing
+end
+
+"""
+    _get_normal_unit_test(
+        test_package::TestPackage,
+        setup_dev_env::Bool,
+        can_fail::Bool,
+        integration_test_repo::GitRepoAddress,
+        integration_test_type::ReleaseVersion,
+        tools_git_repo::GitRepoAddress
+    )::Dict
+
+Creates a normal integration test job for a specific Julia version.
+
+# Args
+- `test_package::TestPackage`: Properties of the package to be tested, such as name and version.
+- `setup_dev_env::Bool`: If the value is true, additional job code is generated that allows the dev
+    or feature branch versions of the QED dependencies to be used.
+- `can_fail::Bool`: If the value is true, add GitLab CI flag `allow_failure: true`.
+- `integration_test_repo::GitRepoAddress`: Git repository URL and branch of the package used for
+    the integration test.
+- `integration_test_type::TestType`: Depending on the type, slightly different unit tests are generated.
+    Read the documentation of the concrete type to get more information.
+- `tools_git_repo::GitRepoAddress`: URL and branch of the Git repository from which the CI tools are
+    cloned in unit test job.
+Return
+
+Returns a dict containing the integration test, which can be output directly as GitLab CI yaml.
+"""
+function _get_normal_unit_test(
+        test_package::TestPackage,
+        setup_dev_env::Bool,
+        can_fail::Bool,
+        integration_test_repo::GitRepoAddress,
+        integration_test_type::ReleaseVersion,
+        tools_git_repo::GitRepoAddress
+    )::Dict
     script = ["apt update", "apt install -y git", "cd /"]
 
     if setup_dev_env
@@ -84,7 +189,7 @@ function add_integration_test_job_yaml!(
     push!(script, "julia --project=. -e 'import Pkg; Pkg.instantiate()'")
     push!(script, "julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'")
 
-    current_job_yaml = Dict(
+    job_yaml = Dict(
         "image" => "julia:$(integration_test_type.version)",
         "stage" => "integ-test",
         "variables" => Dict(
@@ -97,28 +202,9 @@ function add_integration_test_job_yaml!(
         "script" => script,
     )
 
-    if test_platform == AMDGPU
-        _add_julia_rocm_environment!(current_job_yaml, integration_test_type)
-    end
-
-    if test_platform == CPU
-        current_job_yaml["tags"] = ["cpuonly"]
-    elseif test_platform == CUDA
-        current_job_yaml["tags"] = ["cuda", "x86_64"]
-    elseif test_platform == AMDGPU
-        current_job_yaml["tags"] = ["rocm", "x86_64"]
-    else
-        throw(
-            ArgumentError(
-                "test_platform argument with value $(test_platform) not supported"
-            ),
-        )
-    end
-
     if can_fail
-        current_job_yaml["allow_failure"] = true
+        job_yaml["allow_failure"] = true
     end
 
-    job_dict["integration_test_$(integration_test_name)"] = current_job_yaml
-    return nothing
+    return job_yaml
 end

--- a/.ci/CI/src/modules/UnitTest/TestJob.jl
+++ b/.ci/CI/src/modules/UnitTest/TestJob.jl
@@ -26,31 +26,71 @@ contains all properties to be directly translated to GitLab CI yaml.
 """
 function add_unit_test_job_yaml! end
 
+_get_unit_test_name_prefix(test_platform::TestPlatform) = "unit_test_julia_" * lowercase(get_platform_name(test_platform))
+
 function add_unit_test_job_yaml!(
         job_dict::Dict,
         test_package::TestPackage,
         setup_dev_env::Bool,
         unit_test_type::ReleaseVersion,
-        test_platform::TestPlatform = CPU,
+        test_platform::CPU,
         tools_git_repo::GitRepoAddress = GitRepoAddress(
             "https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git", "dev"
         )
     )
-    if test_platform in [ONEAPI, METAL]
-        throw(ArgumentError("argument test_platform not implemented for $(test_platform)"))
-    end
-
     _add_stage_once!(job_dict, "unit-test")
     job_yaml = _get_normal_unit_test(
         unit_test_type.version, test_package, setup_dev_env, test_platform, tools_git_repo
     )
+    job_yaml["tags"] = ["cpuonly"]
 
-    if test_platform == AMDGPU
-        _add_julia_rocm_environment!(job_yaml, unit_test_type)
-    end
+    job_name = _get_unit_test_name_prefix(test_platform)
+    job_name *= "_" * replace(unit_test_type.version, "." => "_")
+    job_dict[job_name] = job_yaml
+    return nothing
+end
 
-    job_name = "unit_test_julia_$(lowercase(string(test_platform)))_$(replace(unit_test_type.version, "." => "_"))"
+function add_unit_test_job_yaml!(
+        job_dict::Dict,
+        test_package::TestPackage,
+        setup_dev_env::Bool,
+        unit_test_type::ReleaseVersion,
+        test_platform::CUDA,
+        tools_git_repo::GitRepoAddress = GitRepoAddress(
+            "https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git", "dev"
+        )
+    )
+    _add_stage_once!(job_dict, "unit-test")
+    job_yaml = _get_normal_unit_test(
+        unit_test_type.version, test_package, setup_dev_env, test_platform, tools_git_repo
+    )
+    job_yaml["tags"] = ["cuda", "x86_64"]
 
+    job_name = _get_unit_test_name_prefix(test_platform)
+    job_name *= "_" * replace(unit_test_type.version, "." => "_")
+    job_dict[job_name] = job_yaml
+    return nothing
+end
+
+function add_unit_test_job_yaml!(
+        job_dict::Dict,
+        test_package::TestPackage,
+        setup_dev_env::Bool,
+        unit_test_type::ReleaseVersion,
+        test_platform::AMDGPU,
+        tools_git_repo::GitRepoAddress = GitRepoAddress(
+            "https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git", "dev"
+        )
+    )
+    _add_stage_once!(job_dict, "unit-test")
+    job_yaml = _get_normal_unit_test(
+        unit_test_type.version, test_package, setup_dev_env, test_platform, tools_git_repo
+    )
+    _add_julia_rocm_environment!(job_yaml, unit_test_type)
+    job_yaml["tags"] = ["rocm", "x86_64"]
+
+    job_name = _get_unit_test_name_prefix(test_platform)
+    job_name *= "_" * replace(unit_test_type.version, "." => "_")
     job_dict[job_name] = job_yaml
     return nothing
 end
@@ -60,22 +100,20 @@ function add_unit_test_job_yaml!(
         test_package::TestPackage,
         setup_dev_env::Bool,
         unit_test_type::ReleaseCandidate,
-        test_platform::TestPlatform = CPU,
+        test_platform::CPU,
         tools_git_repo::GitRepoAddress = GitRepoAddress(
             "https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git", "dev"
         )
     )
-    if test_platform != CPU
-        throw(ArgumentError("argument test_platform not implemented for $(test_platform)"))
-    end
-
     _add_stage_once!(job_dict, "unit-test")
     job_yaml = _get_normal_unit_test(
         "rc", test_package, setup_dev_env, test_platform, tools_git_repo
     )
     job_yaml["allow_failure"] = true
+    job_yaml["tags"] = ["cpuonly"]
 
-    job_name = "unit_test_julia_$(lowercase(string(test_platform)))_release_candidate"
+    job_name = _get_unit_test_name_prefix(test_platform)
+    job_name *= "_release_candidate"
 
     job_dict[job_name] = job_yaml
     return nothing
@@ -86,15 +124,11 @@ function add_unit_test_job_yaml!(
         test_package::TestPackage,
         setup_dev_env::Bool,
         unit_test_type::Nightly,
-        test_platform::TestPlatform = CPU,
+        test_platform::CPU,
         tools_git_repo::GitRepoAddress = GitRepoAddress(
             "https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git", "dev"
         )
     )
-    if test_platform != CPU
-        throw(ArgumentError("argument test_platform not implemented for $(test_platform)"))
-    end
-
     _add_stage_once!(job_dict, "unit-test")
     job_yaml = _get_normal_unit_test(
         "nightly", test_package, setup_dev_env, test_platform, tools_git_repo
@@ -128,8 +162,10 @@ fi",
         "cp -r \$JULIA_EXTRACT_FOLDER/* /usr",
     ]
     job_yaml["allow_failure"] = true
+    job_yaml["tags"] = ["cpuonly"]
 
-    job_name = "unit_test_julia_$(lowercase(string(test_platform)))_nightly"
+    job_name = _get_unit_test_name_prefix(test_platform)
+    job_name *= "_nightly"
 
     job_dict[job_name] = job_yaml
     return nothing
@@ -180,8 +216,8 @@ function _get_normal_unit_test(
         job_yaml["variables"] = Dict()
     end
 
-    for tp in instances(TestPlatform)
-        job_yaml["variables"]["TEST_$(tp)"] = (tp == test_platform) ? "1" : "0"
+    for tp in TestPlatforms
+        job_yaml["variables"]["TEST_$(get_platform_name(tp))"] = (tp == test_platform) ? "1" : "0"
     end
 
     script = [
@@ -211,20 +247,6 @@ function _get_normal_unit_test(
     job_yaml["script"] = script
 
     job_yaml["interruptible"] = true
-
-    if test_platform == CPU
-        job_yaml["tags"] = ["cpuonly"]
-    elseif test_platform == CUDA
-        job_yaml["tags"] = ["cuda", "x86_64"]
-    elseif test_platform == AMDGPU
-        job_yaml["tags"] = ["rocm", "x86_64"]
-    else
-        throw(
-            ArgumentError(
-                "test_platform argument with value $(test_platform) not supported"
-            ),
-        )
-    end
 
     return job_yaml
 end

--- a/.ci/CI/test/IntegrationTest/amdgpu_integration_test.jl
+++ b/.ci/CI/test/IntegrationTest/amdgpu_integration_test.jl
@@ -11,7 +11,7 @@
             "feature42"
         ),
         CI.ReleaseVersion("1.13"),
-        CI.AMDGPU,
+        CI.AMDGPU(),
         CI.GitRepoAddress(
             "https://github.com/fork/QED.jl.git",
             "feature47"

--- a/.ci/CI/test/IntegrationTest/cuda_integration_test.jl
+++ b/.ci/CI/test/IntegrationTest/cuda_integration_test.jl
@@ -11,7 +11,7 @@
             "feature42"
         ),
         CI.ReleaseVersion("1.13"),
-        CI.CUDA,
+        CI.CUDA(),
         CI.GitRepoAddress(
             "https://github.com/fork/QED.jl.git",
             "feature47"

--- a/.ci/CI/test/IntegrationTest/main_branch_integ_test.jl
+++ b/.ci/CI/test/IntegrationTest/main_branch_integ_test.jl
@@ -12,7 +12,7 @@
                 "main"
             ),
             CI.ReleaseVersion("1.10"),
-            CI.CPU,
+            CI.CPU(),
             CI.GitRepoAddress("", "")
         )
 
@@ -75,7 +75,7 @@
                 "feature1"
             ),
             CI.ReleaseVersion("1.12"),
-            CI.CPU,
+            CI.CPU(),
             CI.GitRepoAddress("", "")
         )
 

--- a/.ci/CI/test/IntegrationTest/setup_dev_env_integ_test.jl
+++ b/.ci/CI/test/IntegrationTest/setup_dev_env_integ_test.jl
@@ -11,7 +11,7 @@
             "feature42"
         ),
         CI.ReleaseVersion("1.9"),
-        CI.CPU,
+        CI.CPU(),
         CI.GitRepoAddress(
             "https://github.com/fork/QED.jl.git",
             "feature47"

--- a/.ci/CI/test/UnitTest/amdgpu_unit_test.jl
+++ b/.ci/CI/test/UnitTest/amdgpu_unit_test.jl
@@ -20,7 +20,7 @@
             test_package,
             setup_dev_env,
             CI.ReleaseVersion(version),
-            CI.AMDGPU,
+            CI.AMDGPU(),
             tools_git_repo
         )
 

--- a/.ci/CI/test/UnitTest/cuda_unit_test.jl
+++ b/.ci/CI/test/UnitTest/cuda_unit_test.jl
@@ -18,7 +18,7 @@
             test_package,
             setup_dev_env,
             CI.ReleaseVersion(version),
-            CI.CUDA,
+            CI.CUDA(),
             tools_git_repo
         )
 

--- a/.ci/CI/test/UnitTest/nightly_unit_test.jl
+++ b/.ci/CI/test/UnitTest/nightly_unit_test.jl
@@ -40,7 +40,7 @@ fi",
             test_package,
             setup_dev_env,
             CI.Nightly(nightly_image),
-            CI.CPU,
+            CI.CPU(),
             tools_git_repo
         )
 

--- a/.ci/CI/test/UnitTest/normal_unit_test.jl
+++ b/.ci/CI/test/UnitTest/normal_unit_test.jl
@@ -18,7 +18,7 @@
             test_package,
             setup_dev_env,
             CI.ReleaseVersion(version),
-            CI.CPU,
+            CI.CPU(),
             tools_git_repo
         )
 

--- a/.ci/CI/test/UnitTest/release_unit_test.jl
+++ b/.ci/CI/test/UnitTest/release_unit_test.jl
@@ -20,7 +20,7 @@
             test_package,
             setup_dev_env,
             CI.ReleaseCandidate(),
-            CI.CPU,
+            CI.CPU(),
             tools_git_repo
         )
 

--- a/.ci/CI/test/UnitTest/utils.jl
+++ b/.ci/CI/test/UnitTest/utils.jl
@@ -49,8 +49,8 @@ function get_generic_unit_job(
         "CI_TEST_TYPE" => "unit",
     )
 
-    for tp in instances(CI.TestPlatform)
-        job_yaml["variables"]["TEST_$(tp)"] = "0"
+    for tp in CI.TestPlatforms
+        job_yaml["variables"]["TEST_$(CI.get_platform_name(tp))"] = "0"
     end
 
     job_yaml["interruptible"] = true


### PR DESCRIPTION
Before, the platform argument was an enum. Therefore multiple dispatch was not possible. Change the enum to different types with the same abstract base type.

@AntonReinhard idea ;-)