### PR TITLE
add GetLabCIConf.jl script

### DIFF
--- a/.ci/CI/Project.toml
+++ b/.ci/CI/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 IntegrationTests = "6be7cfa2-1838-408e-bc49-3a824ac3a1fb"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -16,6 +17,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 ArgParse = "1.2.0"
+GitHub = "5.9.0"
 julia = "1"
 
 [extras]

--- a/.ci/CI/README.md
+++ b/.ci/CI/README.md
@@ -44,6 +44,14 @@ The script `SetupDevEnv.jl` checks the dependencies of the current project and p
 julia --project=. script/SetupDevEnv.jl /path/to/the/julia/environment
 ```
 
+# GetGitLabCIConf.jl
+
+`GetGitLabCIConf.jl` reads the environment variable `CI_COMMIT_REF_NAME`. Depending on the value, it creates the environment variables for `Bootloader.jl`. If the value of `CI_COMMIT_REF_NAME` encodes a reference to a GitHub pull request, all public information is pulled from it. The following information is grepped from the pull request.
+
+## Pull Request Label support
+
+If the pull request sets labels starting with `CI:`, `GetGitLabCIConf.jl` will parse them and compare them with dict [know_tags](./src/modules/GitLabCIConf/SetEnvVariables.jl). It removes the prefix `CI: ` (including spaces), strip the string and checks if it is defined in the `know_tags`. If it is defined, the corresponding environment variables are set.
+
 ## Optional Environment variables
 
 All dependencies are added via `Pkg.develop("dep_name")` by default. Therefore the default development branch is used. To set a custom URL, you can define the environment variables `CI_UNIT_PKG_URL_<dep_name>`. For example, you set the environment variable `CI_UNIT_PKG_URL_QEDbase=https://github.com/User/QEDbase.jl#feature1`, the script will execute the command `Pkg.develop(url="https://github.com/User/QEDbase.jl#feature1")`, when the dependency QEDbase was found and matched in the `Project.toml`. Then the branch `feature1` from `https://github.com/User/QEDbase.jl` is used as a dependency.

--- a/.ci/CI/script/GetGitLabCIConf.jl
+++ b/.ci/CI/script/GetGitLabCIConf.jl
@@ -108,6 +108,10 @@ if abspath(PROGRAM_FILE) == @__FILE__
         handle_normal_commit!(ci_commit_ref_name, output_env_vars)
     end
 
+    if output_env_vars["CI_QED_TARGET_BRANCH"] != "main"
+        CI.read_commit_message!(output_env_vars)
+    end
+
     if !check_output_variables(output_env_vars)
         exit(1)
     end

--- a/.ci/CI/script/GetGitLabCIConf.jl
+++ b/.ci/CI/script/GetGitLabCIConf.jl
@@ -1,95 +1,5 @@
 using CI
 
-"""
-    get_output_variables()::Dict{String, String}
-
-# Returns
-
-A Dict containing environment variables without value. During script runtime, the values needs to be
-set. Otherwise the script will exit with an error.
-"""
-function get_output_variables()::Dict{String, String}
-    required_output_variables = [
-        "CI_QED_TARGET_BRANCH",
-        "CI_QED_IS_PR",
-    ]
-
-    output_env_vars = Dict{String, String}()
-    for var_name in required_output_variables
-        output_env_vars[var_name] = ""
-    end
-    return output_env_vars
-end
-
-"""
-    check_output_variables(output_variables::Dict{String, String})::Bool
-
-Checks if one of the environment variables has an empty value.
-
-# Args
-- `output_variables::Dict{String, String}`: Dict with environment variables
-
-# Return
-
-Return `true`, if no value is empty.
-"""
-function check_output_variables(output_variables::Dict{String, String})::Bool
-    non_empty_var = true
-    for (name, value) in output_env_vars
-        if value == ""
-            @error "Internal error: output variable $(name) is empty"
-            global non_empty_var
-            non_empty_var = false
-        end
-    end
-    return non_empty_var
-end
-
-"""
-    handle_pull_request!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
-
-Handle the case, if a pull request is encoded in the `CI_COMMIT_REF_NAME` environment variable.
-Write several environment variable values to `output_env_vars`.
-
-# Args
-- `ci_commit_ref_name::AbstractString`: Content of the `CI_COMMIT_REF_NAME` environment variable.
-- `output_env_vars::Dict{String, String}`: Environment variables for the output.
-"""
-function handle_pull_request!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
-    output_env_vars["CI_QED_IS_PR"] = "ON"
-    pull_request_info = CI.parse_gitlab_ci_pull_request(ci_commit_ref_name)
-    @info "Pull request info:\n$(CI.github_pr_to_string(pull_request_info))"
-    pr = CI.pull_github_pull_request(pull_request_info)
-
-    output_env_vars["CI_QED_TARGET_BRANCH"] = pr.base.ref
-    return nothing
-end
-
-"""
-    handle_normal_commit!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
-
-Handle the case, if the `CI_COMMIT_REF_NAME` environment variable points to a normal commit.
-Write several environment variable values to `output_env_vars`.
-
-# Args
-- `ci_commit_ref_name::AbstractString`: Content of the `CI_COMMIT_REF_NAME` environment variable.
-- `output_env_vars::Dict{String, String}`: Environment variables for the output.
-"""
-function handle_normal_commit!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
-    output_env_vars["CI_QED_IS_PR"] = "OFF"
-    @info "Commit is not part of a pull request"
-
-    # If the commit is not a pull request, CI_COMMIT_REF_NAME stores the target branch name
-    # Special case: for version tags we use the same rules like for the main branch
-    try
-        VersionNumber(ci_commit_ref_name)
-        output_env_vars["CI_QED_TARGET_BRANCH"] = "main"
-    catch
-        output_env_vars["CI_QED_TARGET_BRANCH"] = ci_commit_ref_name
-    end
-    return nothing
-end
-
 if abspath(PROGRAM_FILE) == @__FILE__
     if !haskey(ENV, "CI_COMMIT_REF_NAME")
         @error "Environment variable CI_COMMIT_REF_NAME is not set."
@@ -99,20 +9,20 @@ if abspath(PROGRAM_FILE) == @__FILE__
     ci_commit_ref_name = ENV["CI_COMMIT_REF_NAME"]
     @info "CI_COMMIT_REF_NAME: $(ci_commit_ref_name)"
 
-    output_env_vars = get_output_variables()
+    output_env_vars = CI.get_output_variables()
 
     pull_request = CI.is_pull_request(ci_commit_ref_name)
     if pull_request
-        handle_pull_request!(ci_commit_ref_name, output_env_vars)
+        CI.handle_pull_request!(ci_commit_ref_name, output_env_vars)
     else
-        handle_normal_commit!(ci_commit_ref_name, output_env_vars)
+        CI.handle_normal_commit!(ci_commit_ref_name, output_env_vars)
     end
 
     if output_env_vars["CI_QED_TARGET_BRANCH"] != "main"
         CI.read_commit_message!(output_env_vars)
     end
 
-    if !check_output_variables(output_env_vars)
+    if !CI.check_output_variables(output_env_vars)
         exit(1)
     end
 

--- a/.ci/CI/script/GetGitLabCIConf.jl
+++ b/.ci/CI/script/GetGitLabCIConf.jl
@@ -1,0 +1,119 @@
+using CI
+
+"""
+    get_output_variables()::Dict{String, String}
+
+# Returns
+
+A Dict containing environment variables without value. During script runtime, the values needs to be
+set. Otherwise the script will exit with an error.
+"""
+function get_output_variables()::Dict{String, String}
+    required_output_variables = [
+        "CI_QED_TARGET_BRANCH",
+        "CI_QED_IS_PR",
+    ]
+
+    output_env_vars = Dict{String, String}()
+    for var_name in required_output_variables
+        output_env_vars[var_name] = ""
+    end
+    return output_env_vars
+end
+
+"""
+    check_output_variables(output_variables::Dict{String, String})::Bool
+
+Checks if one of the environment variables has an empty value.
+
+# Args
+- `output_variables::Dict{String, String}`: Dict with environment variables
+
+# Return
+
+Return `true`, if no value is empty.
+"""
+function check_output_variables(output_variables::Dict{String, String})::Bool
+    non_empty_var = true
+    for (name, value) in output_env_vars
+        if value == ""
+            @error "Internal error: output variable $(name) is empty"
+            global non_empty_var
+            non_empty_var = false
+        end
+    end
+    return non_empty_var
+end
+
+"""
+    handle_pull_request!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
+
+Handle the case, if a pull request is encoded in the `CI_COMMIT_REF_NAME` environment variable.
+Write several environment variable values to `output_env_vars`.
+
+# Args
+- `ci_commit_ref_name::AbstractString`: Content of the `CI_COMMIT_REF_NAME` environment variable.
+- `output_env_vars::Dict{String, String}`: Environment variables for the output.
+"""
+function handle_pull_request!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
+    output_env_vars["CI_QED_IS_PR"] = "ON"
+    pull_request_info = CI.parse_gitlab_ci_pull_request(ci_commit_ref_name)
+    @info "Pull request info:\n$(CI.github_pr_to_string(pull_request_info))"
+    pr = CI.pull_github_pull_request(pull_request_info)
+
+    output_env_vars["CI_QED_TARGET_BRANCH"] = pr.base.ref
+    return nothing
+end
+
+"""
+    handle_normal_commit!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
+
+Handle the case, if the `CI_COMMIT_REF_NAME` environment variable points to a normal commit.
+Write several environment variable values to `output_env_vars`.
+
+# Args
+- `ci_commit_ref_name::AbstractString`: Content of the `CI_COMMIT_REF_NAME` environment variable.
+- `output_env_vars::Dict{String, String}`: Environment variables for the output.
+"""
+function handle_normal_commit!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
+    output_env_vars["CI_QED_IS_PR"] = "OFF"
+    @info "Commit is not part of a pull request"
+
+    # If the commit is not a pull request, CI_COMMIT_REF_NAME stores the target branch name
+    # Special case: for version tags we use the same rules like for the main branch
+    try
+        VersionNumber(ci_commit_ref_name)
+        output_env_vars["CI_QED_TARGET_BRANCH"] = "main"
+    catch
+        output_env_vars["CI_QED_TARGET_BRANCH"] = ci_commit_ref_name
+    end
+    return nothing
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    if !haskey(ENV, "CI_COMMIT_REF_NAME")
+        @error "Environment variable CI_COMMIT_REF_NAME is not set."
+        exit(1)
+    end
+
+    ci_commit_ref_name = ENV["CI_COMMIT_REF_NAME"]
+    @info "CI_COMMIT_REF_NAME: $(ci_commit_ref_name)"
+
+    output_env_vars = get_output_variables()
+
+    pull_request = CI.is_pull_request(ci_commit_ref_name)
+    if pull_request
+        handle_pull_request!(ci_commit_ref_name, output_env_vars)
+    else
+        handle_normal_commit!(ci_commit_ref_name, output_env_vars)
+    end
+
+    if !check_output_variables(output_env_vars)
+        exit(1)
+    end
+
+    for (name, value) in output_env_vars
+        println("export $(name)=$(value)")
+    end
+
+end

--- a/.ci/CI/script/SetupDevEnv.jl
+++ b/.ci/CI/script/SetupDevEnv.jl
@@ -24,26 +24,6 @@ using LibGit2
 using CI
 using Pkg
 
-"""
-    get_test_specific_custom_urls(::CI.TestType, urls::CI.CustomDependencyUrls)::Dict{String, String}
-
-Return a reference to the dict containing the custom repository URLs for the given test type.
-
-# Returns
-
-The key is the name of the package and the value the custom URL.
-"""
-function get_test_specific_custom_urls end
-
-get_test_specific_custom_urls(
-    ::CI.UnitTest, urls::CI.CustomDependencyUrls
-)::Dict{String, String} = urls.unit
-
-get_test_specific_custom_urls(
-    ::CI.IntegrationTest, urls::CI.CustomDependencyUrls
-)::Dict{String, String} = urls.integ
-
-
 if abspath(PROGRAM_FILE) == @__FILE__
     try
         if length(ARGS) < 1
@@ -73,7 +53,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
             @info "Disable custom URLs for QED dependencies"
         end
 
-        test_specific_custom_urls = get_test_specific_custom_urls(
+        test_specific_custom_urls = CI.get_test_specific_custom_urls(
             test_type, custom_dependency_urls
         )
         if !isempty(test_specific_custom_urls)

--- a/.ci/CI/script/SetupDevEnv.jl
+++ b/.ci/CI/script/SetupDevEnv.jl
@@ -53,7 +53,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
             @info "Disable custom URLs for QED dependencies"
         end
 
-        test_specific_custom_urls = get_test_specific_custom_urls(
+        test_specific_custom_urls = CI.get_test_specific_custom_urls(
             test_type, custom_dependency_urls
         )
         if !isempty(test_specific_custom_urls)

--- a/.ci/CI/script/SetupDevEnv.jl
+++ b/.ci/CI/script/SetupDevEnv.jl
@@ -53,7 +53,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
             @info "Disable custom URLs for QED dependencies"
         end
 
-        test_specific_custom_urls = CI.get_test_specific_custom_urls(
+        test_specific_custom_urls = get_test_specific_custom_urls(
             test_type, custom_dependency_urls
         )
         if !isempty(test_specific_custom_urls)

--- a/.ci/CI/src/CI.jl
+++ b/.ci/CI/src/CI.jl
@@ -6,4 +6,5 @@ include("modules/UnitTest.jl")
 include("modules/IntegTest.jl")
 include("modules/GitLabTargetBranch.jl")
 include("modules/SetupDevEnv.jl")
+include("modules/GitLabCIConf.jl")
 end

--- a/.ci/CI/src/modules/GitLabCIConf.jl
+++ b/.ci/CI/src/modules/GitLabCIConf.jl
@@ -1,3 +1,4 @@
 include("GitLabCIConf/GitLabCICommitRef.jl")
 include("GitLabCIConf/GetGitHubPR.jl")
 include("GitLabCIConf/SetEnvVariables.jl")
+include("GitLabCIConf/IOEnvVariables.jl")

--- a/.ci/CI/src/modules/GitLabCIConf.jl
+++ b/.ci/CI/src/modules/GitLabCIConf.jl
@@ -1,0 +1,2 @@
+include("GitLabCIConf/GitLabCICommitRef.jl")
+include("GitLabCIConf/GetGitHubPR.jl")

--- a/.ci/CI/src/modules/GitLabCIConf.jl
+++ b/.ci/CI/src/modules/GitLabCIConf.jl
@@ -1,2 +1,3 @@
 include("GitLabCIConf/GitLabCICommitRef.jl")
 include("GitLabCIConf/GetGitHubPR.jl")
+include("GitLabCIConf/SetEnvVariables.jl")

--- a/.ci/CI/src/modules/GitLabCIConf/GetGitHubPR.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/GetGitHubPR.jl
@@ -1,0 +1,31 @@
+using GitHub
+
+# cache pull request information
+github_pr_cache = Dict{GitHubPR, GitHub.PullRequest}()
+
+"""
+    pull_github_pull_request(gh_pr::GitHubPR)::GitHub.PullRequest
+
+Do a web request and get information about an pull request.
+
+# Args
+
+- `github_pull_request_info::GitHubPR`: Contains "address" of the pull request.
+
+# Return
+
+All information about the pull request.
+"""
+function pull_github_pull_request(github_pull_request_info::GitHubPR)::GitHub.PullRequest
+    if haskey(github_pr_cache, github_pull_request_info)
+        @info "use cached pull request object"
+        return github_pr_cache[github_pull_request_info]
+    end
+
+    pr_object = GitHub.pull_request(
+        "$(github_pull_request_info.user)/$(github_pull_request_info.project)",
+        github_pull_request_info.pr_number
+    )
+    github_pr_cache[github_pull_request_info] = pr_object
+    return pr_object
+end

--- a/.ci/CI/src/modules/GitLabCIConf/GetGitHubPR.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/GetGitHubPR.jl
@@ -4,28 +4,53 @@ using GitHub
 github_pr_cache = Dict{GitHubPR, GitHub.PullRequest}()
 
 """
-    pull_github_pull_request(gh_pr::GitHubPR)::GitHub.PullRequest
+    pull_github_pull_request(
+        github_pull_request_info::GitHubPR,
+        max_retries::Integer = 5,
+        wait_time::Integer = 20
+    )::GitHub.PullRequest
 
 Do a web request and get information about an pull request.
 
 # Args
 
 - `github_pull_request_info::GitHubPR`: Contains "address" of the pull request.
+- `max_retries::Integer`: Number of attempts to pull the GitHub pull request information in case of
+    a connection problem.
+- `wait_time::Integer`: Time in seconds that is waited between two attempts.
 
 # Return
 
 All information about the pull request.
 """
-function pull_github_pull_request(github_pull_request_info::GitHubPR)::GitHub.PullRequest
+function pull_github_pull_request(
+        github_pull_request_info::GitHubPR,
+        max_retries::Integer = 5,
+        wait_time::Integer = 20
+    )::GitHub.PullRequest
     if haskey(github_pr_cache, github_pull_request_info)
         @info "use cached pull request object"
         return github_pr_cache[github_pull_request_info]
     end
 
-    pr_object = GitHub.pull_request(
-        "$(github_pull_request_info.user)/$(github_pull_request_info.project)",
-        github_pull_request_info.pr_number
-    )
-    github_pr_cache[github_pull_request_info] = pr_object
-    return pr_object
+
+    for i in 1:max_retries
+        try
+            pr_object = GitHub.pull_request(
+                "$(github_pull_request_info.user)/$(github_pull_request_info.project)",
+                github_pull_request_info.pr_number
+            )
+            github_pr_cache[github_pull_request_info] = pr_object
+            return pr_object
+        catch e
+            if i < max_retries
+                @warn "Time out for fetching pull request information.\n" *
+                    "Sleep $(wait_time) seconds and try again."
+                sleep(wait_time)
+            else
+                throw(e)
+            end
+        end
+    end
+    return
 end

--- a/.ci/CI/src/modules/GitLabCIConf/GitLabCICommitRef.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/GitLabCICommitRef.jl
@@ -50,7 +50,7 @@ function parse_gitlab_ci_pull_request(
     if (pr_number <= 0)
         throw(
             ErrorException(
-                "A PR number always needs to be a positive integer number bigger than 0: $pr_number",
+                "a PR number always needs to be a positive integer number bigger than 0: $pr_number",
             )
         )
     end

--- a/.ci/CI/src/modules/GitLabCIConf/GitLabCICommitRef.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/GitLabCICommitRef.jl
@@ -1,0 +1,61 @@
+"""
+    is_github_pull_request(ci_commit_ref_name::AbstractString)::Bool
+
+Check if `ci_commit_ref_name` could point to a GitHub Pull Request.
+`CI_COMMIT_REF_NAME` has a special shape in GitLab CI if it points to a GitHub Pull Request.
+The shape is `pr-<PR number>/<repo owner of the source branch>/<project name>/<source branch name>`, 
+e.g: `pr-41/SimeonEhrig/QuantumElectrodynamics.jl/setDevDepDeps`
+"""
+is_github_pull_request(ci_commit_ref_name::AbstractString)::Bool = startswith(ci_commit_ref_name, "pr-")
+
+
+"""
+    parse_gitlab_ci_pull_request(
+        ci_commit_ref_name::AbstractString,
+        github_user::AbstractString = "QEDjl-project"
+    )::GitHubPR
+   
+Parse `ci_commit_ref_name` and return GitHubPR information object.
+
+# Args
+- `ci_commit_ref_name::AbstractString`: String to be parsed. See docstring of `is_github_pull_request`.
+- `github_user::AbstractString`: Overwrites GitHub user with this value in the returned object (default: "QEDjl-project")
+
+# Return
+
+Information about the related GitHub Pull Request 
+"""
+function parse_gitlab_ci_pull_request(
+        ci_commit_ref_name::AbstractString,
+        github_user::AbstractString = "QEDjl-project"
+    )::GitHubPR
+    split_commit_ref_name = split(ci_commit_ref_name, "/")
+
+    if length(split_commit_ref_name) < 3
+        throw(ErrorException("ci_commit_ref_name cannot be spited in 3 or more components."))
+    end
+
+    for component in split_commit_ref_name
+        if component == ""
+            throw(ErrorException("one of the components of ci_commit_ref_name is empty."))
+        end
+    end
+
+    if (!startswith(split_commit_ref_name[1], "pr-"))
+        throw(ErrorException("ci_commit_ref_name needs to start with `pr-`"))
+    end
+
+    # parse to Int only to check if it is a number
+    pr_number = parse(Int, split_commit_ref_name[1][(length("pr-") + 1):end])
+    if (pr_number <= 0)
+        throw(
+            ErrorException(
+                "A PR number always needs to be a positive integer number bigger than 0: $pr_number",
+            )
+        )
+    end
+
+    repository_name = split_commit_ref_name[3]
+
+    return GitHubPR(github_user, repository_name, pr_number)
+end

--- a/.ci/CI/src/modules/GitLabCIConf/IOEnvVariables.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/IOEnvVariables.jl
@@ -1,0 +1,44 @@
+"""
+    get_output_variables()::Dict{String, String}
+
+# Returns
+
+A Dict containing environment variables without value. During script runtime, the values needs to be
+set. Otherwise the script will exit with an error.
+"""
+function get_output_variables()::Dict{String, String}
+    required_output_variables = [
+        "CI_QED_TARGET_BRANCH",
+        "CI_QED_IS_PR",
+    ]
+
+    output_env_vars = Dict{String, String}()
+    for var_name in required_output_variables
+        output_env_vars[var_name] = ""
+    end
+    return output_env_vars
+end
+
+"""
+    check_output_variables(output_variables::Dict{String, String})::Bool
+
+Checks if one of the environment variables has an empty value.
+
+# Args
+- `output_variables::Dict{String, String}`: Dict with environment variables
+
+# Return
+
+Return `true`, if no value is empty.
+"""
+function check_output_variables(output_variables::Dict{String, String})::Bool
+    non_empty_var = true
+    for (name, value) in output_variables
+        if value == ""
+            @error "Internal error: output variable $(name) is empty"
+            global non_empty_var
+            non_empty_var = false
+        end
+    end
+    return non_empty_var
+end

--- a/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
@@ -2,7 +2,7 @@ using GitHub
 
 # define which environment variables should be set, if tag is found
 # it is not allow the set the same environment variable with different values
-const know_tags = Dict{String, Vector{Tuple{String, String}}}(
+const known_tags = Dict{String, Vector{Tuple{String, String}}}(
     "doc" => [
         ("CI_QED_ENABLE_CPU_TESTS", "OFF"),
         ("CI_QED_ENABLE_CUDA_TESTS", "OFF"),
@@ -55,7 +55,7 @@ end
     _read_pull_request_labels!(pr::GitHub.PullRequest, output_env_vars::Dict{String, String})
 
 Reads the labels from the given pull request. If a label begins with `CI:`, the prefix is removed
-and a check is made to see whether it is defined in `know_tags`. If it is defined, the
+and a check is made to see whether it is defined in `known_tags`. If it is defined, the
 corresponding environment variables are added to `output_env_vars`.
 
 # Args
@@ -64,17 +64,17 @@ corresponding environment variables are added to `output_env_vars`.
 
 """
 function _read_pull_request_labels!(pr::GitHub.PullRequest, output_env_vars::Dict{String, String})
-    global know_tags
+    global known_tags
 
     io = IOBuffer()
     for label in pr.labels
         if startswith(label.name, "CI:")
             println(io, label.name)
             tag = strip(label.name[(length("CI:") + 1):end])
-            if !haskey(know_tags, tag)
+            if !haskey(known_tags, tag)
                 @warn "Unknown tag: $(tag)"
             else
-                for (env_var_name, env_var_value) in know_tags[tag]
+                for (env_var_name, env_var_value) in known_tags[tag]
                     output_env_vars[env_var_name] = env_var_value
                 end
             end

--- a/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
@@ -1,3 +1,31 @@
+using GitHub
+
+# define which environment variables should be set, if tag is found
+const know_tags = Dict{String, Vector{Tuple{String, String}}}(
+    "doc" => [
+        ("CI_QED_ENABLE_CPU_TESTS", "OFF"),
+        ("CI_QED_ENABLE_CUDA_TESTS", "OFF"),
+        ("CI_QED_ENABLE_AMDGPU_TESTS", "OFF"),
+        ("CI_QED_ENABLE_INTEG_TESTS", "OFF"),
+    ],
+    "no-cpu-test" => [
+        ("CI_QED_ENABLE_CPU_TESTS", "OFF"),
+    ],
+    "no-gpu-test" => [
+        ("CI_QED_ENABLE_CUDA_TESTS", "OFF"),
+        ("CI_QED_ENABLE_AMDGPU_TESTS", "OFF"),
+    ],
+    "no-cuda-test" => [
+        ("CI_QED_ENABLE_CUDA_TESTS", "OFF"),
+    ],
+    "no-amdgpu-test" => [
+        ("CI_QED_ENABLE_AMDGPU_TESTS", "OFF"),
+    ],
+    "no-integ-test" => [
+        ("CI_QED_ENABLE_INTEG_TESTS", "OFF"),
+    ],
+)
+
 """
     handle_pull_request!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
 
@@ -15,6 +43,44 @@ function handle_pull_request!(ci_commit_ref_name::AbstractString, output_env_var
     pr = CI.pull_github_pull_request(pull_request_info)
 
     output_env_vars["CI_QED_TARGET_BRANCH"] = pr.base.ref
+    _read_pull_request_labels!(pr, output_env_vars)
+    return nothing
+end
+
+"""
+    _read_pull_request_labels!(pr::GitHub.PullRequest, output_env_vars::Dict{String, String})
+
+Reads the labels from the given pull request. If a label begins with `CI:`, the prefix is removed
+and a check is made to see whether it is defined in `know_tags`. If it is defined, the
+corresponding environment variables are added to `output_env_vars`.
+
+# Args
+- `pr::GitHub.PullRequest`: Pull request object with labels
+- `output_env_vars::Dict{String, String}`: Environment variables for the output.
+
+"""
+function _read_pull_request_labels!(pr::GitHub.PullRequest, output_env_vars::Dict{String, String})
+    global know_tags
+
+    io = IOBuffer()
+    for label in pr.labels
+        if startswith(label.name, "CI:")
+            println(io, label.name)
+            tag = strip(label.name[(length("CI:") + 1):end])
+            if !haskey(know_tags, tag)
+                @warn "Unknown tag: $(tag)"
+            else
+                for (env_var_name, env_var_value) in know_tags[tag]
+                    output_env_vars[env_var_name] = env_var_value
+                end
+            end
+        end
+    end
+
+    msg = String(take!(io))
+    if msg != ""
+        @info "found CI labels:\n$(msg)"
+    end
     return nothing
 end
 

--- a/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
@@ -1,4 +1,49 @@
 """
+    handle_pull_request!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
+
+Handle the case, if a pull request is encoded in the `CI_COMMIT_REF_NAME` environment variable.
+Write several environment variable values to `output_env_vars`.
+
+# Args
+- `ci_commit_ref_name::AbstractString`: Content of the `CI_COMMIT_REF_NAME` environment variable.
+- `output_env_vars::Dict{String, String}`: Environment variables for the output.
+"""
+function handle_pull_request!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
+    output_env_vars["CI_QED_IS_PR"] = "ON"
+    pull_request_info = CI.parse_gitlab_ci_pull_request(ci_commit_ref_name)
+    @info "Pull request info:\n$(CI.github_pr_to_string(pull_request_info))"
+    pr = CI.pull_github_pull_request(pull_request_info)
+
+    output_env_vars["CI_QED_TARGET_BRANCH"] = pr.base.ref
+    return nothing
+end
+
+"""
+    handle_normal_commit!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
+
+Handle the case, if the `CI_COMMIT_REF_NAME` environment variable points to a normal commit.
+Write several environment variable values to `output_env_vars`.
+
+# Args
+- `ci_commit_ref_name::AbstractString`: Content of the `CI_COMMIT_REF_NAME` environment variable.
+- `output_env_vars::Dict{String, String}`: Environment variables for the output.
+"""
+function handle_normal_commit!(ci_commit_ref_name::AbstractString, output_env_vars::Dict{String, String})
+    output_env_vars["CI_QED_IS_PR"] = "OFF"
+    @info "Commit is not part of a pull request"
+
+    # If the commit is not a pull request, CI_COMMIT_REF_NAME stores the target branch name
+    # Special case: for version tags we use the same rules like for the main branch
+    try
+        VersionNumber(ci_commit_ref_name)
+        output_env_vars["CI_QED_TARGET_BRANCH"] = "main"
+    catch
+        output_env_vars["CI_QED_TARGET_BRANCH"] = ci_commit_ref_name
+    end
+    return nothing
+end
+
+"""
     read_commit_message!(output_env_vars::Dict{String, String})
 
 Reads the CI commit message defined in the environment variable `CI_COMMIT_MESSAGE`, if set. If it

--- a/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
@@ -1,6 +1,7 @@
 using GitHub
 
 # define which environment variables should be set, if tag is found
+# it is not allow the set the same environment variable with different values
 const know_tags = Dict{String, Vector{Tuple{String, String}}}(
     "doc" => [
         ("CI_QED_ENABLE_CPU_TESTS", "OFF"),
@@ -23,6 +24,9 @@ const know_tags = Dict{String, Vector{Tuple{String, String}}}(
     ],
     "no-integ-test" => [
         ("CI_QED_ENABLE_INTEG_TESTS", "OFF"),
+    ],
+    "large-test" => [
+        ("CI_QED_LARGE_TESTS", "ON"),
     ],
 )
 

--- a/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
+++ b/.ci/CI/src/modules/GitLabCIConf/SetEnvVariables.jl
@@ -1,0 +1,22 @@
+"""
+    read_commit_message!(output_env_vars::Dict{String, String})
+
+Reads the CI commit message defined in the environment variable `CI_COMMIT_MESSAGE`, if set. If it
+finds a line that starts with the environment variable specific prefix for the test type, it parses
+the line and adds the custom URL to `output_env_vars`.
+
+# Args
+- `output_env_vars::Dict{String, String}`: Environment variables for the output.
+"""
+function read_commit_message!(output_env_vars::Dict{String, String})
+    custom_dependency_urls = CustomDependencyUrls()
+    append_custom_dependency_urls_from_git_message!(custom_dependency_urls)
+    for test_type in [UnitTest(), IntegrationTest()]
+        for (name, value) in get_test_specific_custom_urls(test_type, custom_dependency_urls)
+            # TODO: change me to get_test_type_env_var_prefix()
+            env_name = get_test_type_env_var_prefix2(test_type) * name
+            output_env_vars[env_name] = value
+        end
+    end
+    return nothing
+end

--- a/.ci/CI/src/modules/Types.jl
+++ b/.ci/CI/src/modules/Types.jl
@@ -22,6 +22,24 @@ get_test_type_env_var_prefix(::TestType) = error("unknown test type")
 get_test_type_env_var_prefix(::UnitTest) = "CI_UNIT_PKG_URL_"
 get_test_type_env_var_prefix(::IntegrationTest) = "CI_INTG_PKG_URL_"
 
+# TODO: rename me to get_test_type_env_var_prefix(), if Bootloader.jl is moved to script
+"""
+    get_test_type_env_var_prefix2(::TestType)
+
+Depending on the test type, a different prefix for a environment variable name is returned.
+Environment starting with the prefix contains custom dependency URLs.
+
+# Args
+`::TestType` The test type
+
+# Returns
+
+Prefix of variable names that are read in order to obtain user-defined URLs.
+"""
+get_test_type_env_var_prefix2(::TestType) = error("unknown test type")
+get_test_type_env_var_prefix2(::UnitTest) = "CI_QED_UNIT_PKG_URL_"
+get_test_type_env_var_prefix2(::IntegrationTest) = "CI_QED_INTG_PKG_URL_"
+
 """
     get_test_type_name(::TestType)
 
@@ -169,6 +187,26 @@ struct CustomDependencyUrls
 
     CustomDependencyUrls() = new(Dict{String, String}(), Dict{String, String}())
 end
+
+"""
+    get_test_specific_custom_urls(::TestType, urls::CustomDependencyUrls)::Dict{String, String}
+
+Return a reference to the dict containing the custom repository URLs for the given test type.
+
+# Returns
+
+The key is the name of the package and the value the custom URL.
+"""
+function get_test_specific_custom_urls end
+
+get_test_specific_custom_urls(
+    ::UnitTest, urls::CustomDependencyUrls
+)::Dict{String, String} = urls.unit
+
+get_test_specific_custom_urls(
+    ::IntegrationTest, urls::CustomDependencyUrls
+)::Dict{String, String} = urls.integ
+
 
 """
     struct GitHubPR

--- a/.ci/CI/src/modules/Types.jl
+++ b/.ci/CI/src/modules/Types.jl
@@ -169,3 +169,22 @@ struct CustomDependencyUrls
 
     CustomDependencyUrls() = new(Dict{String, String}(), Dict{String, String}())
 end
+
+"""
+    struct GitHubPR
+
+# Members
+- `user::AbstractString`: GitHub user or group
+- `project::AbstractString`: repository name
+- `pr_number::Int`: Pull Request Number
+"""
+struct GitHubPR
+    user::AbstractString
+    project::AbstractString
+    pr_number::Int
+end
+
+Base.:(==)(a::GitHubPR, b::GitHubPR) = a.user == b.user && a.project == b.project && a.pr_number == b.pr_number
+
+"Get String representation of GitHubPR"
+github_pr_to_string(gh_pr::GitHubPR) = "User: $(gh_pr.user)\nProject: $(gh_pr.project)\nPR number: $(gh_pr.pr_number)"

--- a/.ci/CI/src/modules/Utils.jl
+++ b/.ci/CI/src/modules/Utils.jl
@@ -119,7 +119,8 @@ function append_custom_dependency_urls_from_git_message!(
         return nothing
     end
 
-    @info "Git commit message is set."
+    io = IOBuffer()
+    println(io, "Git commit message is set.")
     for line in split(env["CI_COMMIT_MESSAGE"], "\n"), (test_type, url_dict) in test_types
         line = strip(line)
         env_prefix = get_test_type_env_var_prefix(test_type)
@@ -135,10 +136,11 @@ function append_custom_dependency_urls_from_git_message!(
             end
 
             pkg_name = pkg_name[(length(env_prefix) + 1):end]
-            @info "add $(pkg_name)=$(url) to $(get_test_type_name(test_type)) custom urls"
+            println(io, "add $(pkg_name)=$(url) to $(get_test_type_name(test_type)) custom urls")
             url_dict[pkg_name] = url
         end
     end
+    @info String(take!(io))
     return
 end
 

--- a/.ci/CI/test/GitLabCIConf/GetGitHubPR.jl
+++ b/.ci/CI/test/GitLabCIConf/GetGitHubPR.jl
@@ -1,0 +1,38 @@
+@testset "pull_github_pull_request()" begin
+    @test isempty(CI.github_pr_cache)
+
+    @testset "target dev branch" begin
+        pr_info = CI.GitHubPR("QEDjl-project", "QuantumElectrodynamics.jl", 41)
+        pr = CI.pull_github_pull_request(pr_info)
+
+        @test pr.base.ref == "dev"
+        @test pr.number == 41
+
+        @test length(CI.github_pr_cache) == 1
+        @test pr_info in keys(CI.github_pr_cache)
+    end
+
+    @testset "target main branch" begin
+        pr_info = CI.GitHubPR("QEDjl-project", "QEDprocesses.jl", 92)
+        pr = CI.pull_github_pull_request(pr_info)
+
+        @test pr.base.ref == "main"
+        @test pr.number == 92
+
+        @test length(CI.github_pr_cache) == 2
+        @test pr_info in keys(CI.github_pr_cache)
+
+        @testset "call cached pull request" begin
+            info_logger_io = IOBuffer()
+            info_logger = CI.Logging.ConsoleLogger(info_logger_io, CI.Logging.Info)
+            CI.Logging.with_logger(info_logger) do
+                CI.pull_github_pull_request(pr_info)
+            end
+
+            @test length(CI.github_pr_cache) == 2
+            logger_output = String(take!(info_logger_io))
+
+            @test contains(logger_output, "use cached pull request object")
+        end
+    end
+end

--- a/.ci/CI/test/GitLabCIConf/GitLabCICommitRef.jl
+++ b/.ci/CI/test/GitLabCIConf/GitLabCICommitRef.jl
@@ -1,0 +1,62 @@
+@testset "is_github_pull_request()" begin
+    @testset "pull request branch names" begin
+        for name in [
+                "pr-92/AntonReinhard/QEDprocesses.jl/setDevDepDeps",
+                "pr-41/SimeonEhrig/QuantumElectrodynamics.jl/setDevDepDeps",
+            ]
+            @test CI.is_github_pull_request(name)
+        end
+    end
+
+    @testset "normal commit names" begin
+        for name in [
+                "dev",
+                "main",
+                "1.0.0",
+                "0.3.7-alpha",
+                "feature1",
+            ]
+            @test CI.is_github_pull_request(name) == false
+        end
+    end
+end
+
+@testset "parse_gitlab_ci_pull_request()" begin
+    @testset "working strings, default user" begin
+        for (name, expected_gh_info) in [
+                (
+                    "pr-92/AntonReinhard/QEDprocesses.jl/setDevDepDeps",
+                    CI.GitHubPR("QEDjl-project", "QEDprocesses.jl", 92),
+                ), (
+                    "pr-41/SimeonEhrig/QuantumElectrodynamics.jl/setDevDepDeps",
+                    CI.GitHubPR("QEDjl-project", "QuantumElectrodynamics.jl", 41),
+
+                ),
+            ]
+            gh_info = CI.parse_gitlab_ci_pull_request(name)
+            @test gh_info.user == expected_gh_info.user
+            @test gh_info.project == expected_gh_info.project
+            @test gh_info.pr_number == expected_gh_info.pr_number
+        end
+    end
+
+    @testset "working strings, custom user" begin
+        gh_info = CI.parse_gitlab_ci_pull_request("pr-42/Group/Project/branch", "CustomGroup")
+        @test gh_info.user == "CustomGroup"
+        @test gh_info.project == "Project"
+        @test gh_info.pr_number == 42
+    end
+
+    @testset "wrong strings" begin
+        # missing project
+        @test_throws ErrorException CI.parse_gitlab_ci_pull_request("pr-42/Group")
+        # missing project
+        @test_throws ErrorException CI.parse_gitlab_ci_pull_request("pr-42/Group/")
+        # pr- prefix missing
+        @test_throws ErrorException CI.parse_gitlab_ci_pull_request("42/Group/Project")
+        # wrong prefix
+        @test_throws ErrorException CI.parse_gitlab_ci_pull_request("p-42/Group/Project")
+        # negativ pr number
+        @test_throws ErrorException CI.parse_gitlab_ci_pull_request("pr--42/Group/Project")
+    end
+end

--- a/.ci/CI/test/GitLabCIConf/runtests.jl
+++ b/.ci/CI/test/GitLabCIConf/runtests.jl
@@ -1,0 +1,2 @@
+include("GitLabCICommitRef.jl")
+include("GetGitHubPR.jl")

--- a/.ci/CI/test/runtests.jl
+++ b/.ci/CI/test/runtests.jl
@@ -11,6 +11,7 @@ else
     include("IntegrationTest/runtests.jl")
     include("Util/runtests.jl")
     include("SetupDevEnv/runtests.jl")
+    include("GitLabCIConf/runtests.jl")
 end
 
 if haskey(ENV, "DISABLE_CI_LONG_TESTS")

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,6 +96,18 @@ bootloader_jl_integration_test:
   tags:
     - cpuonly
 
+get_gitlab_ci_conf_jl_integration_test:
+  image: julia:1.10
+  stage: integration-test
+  script:
+    - cd ${CI_PROJECT_DIR}/.ci/CI/
+    - julia --project=. -e 'import Pkg; Pkg.instantiate()'
+    - $(julia --project=. ${CI_PROJECT_DIR}/.ci/CI/script/GetGitLabCIConf.jl)
+    - env | grep CI_QED_
+  interruptible: true
+  tags:
+    - cpuonly
+
 trigger_job:
   stage: qedcore-integration-test
   variables:


### PR DESCRIPTION
The script is dedicated to run in the GitLab CI. It's compiles information from the predefined GitLab CI environment variables and creates environment variables to configure Bootloader.jl.

part of solution for issue #123

# Source of information
The following information sources will be used:
- The environment variable `CI_COMMIT_REF` in GitLab. It encodes if the pipeline is generated for a pull request or not.
- If it is a pull request
  - the labels of a pull request
  - control commands in the git commit message