### PR TITLE
get_gitlab_ci_conf.jl: allow to overwrite specific environment variables

### DIFF
--- a/.ci/CI/script/get_gitlab_ci_conf.jl
+++ b/.ci/CI/script/get_gitlab_ci_conf.jl
@@ -26,6 +26,12 @@ if abspath(PROGRAM_FILE) == @__FILE__
         exit(1)
     end
 
+    local env_info_output = "Environment variables:\n"
+    for (name, value) in output_env_vars
+        env_info_output *= "  $(name)=$(value)\n"
+    end
+    @info env_info_output
+
     for (name, value) in output_env_vars
         println("export $(name)=$(value)")
     end

--- a/.ci/CI/src/modules/gitlab_ci_conf/set_env_variables.jl
+++ b/.ci/CI/src/modules/gitlab_ci_conf/set_env_variables.jl
@@ -97,7 +97,9 @@ function _read_pull_request_labels!(pr::GitHub.PullRequest, output_env_vars::Dic
                 @warn "Unknown tag: $(tag)"
             else
                 for (env_var_name, env_var_value) in known_tags[tag]
-                    _set_output_env_vars!(output_env_vars, env_var_name, env_var_value)
+                    # do not use _set_output_env_vars!(), as this environment should be variable
+                    # overridable
+                    output_env_vars[env_var_name] = env_var_value
                 end
             end
         end
@@ -151,7 +153,9 @@ function read_commit_message!(output_env_vars::Dict{String, String})
     for test_type in [UnitTest(), IntegrationTest()]
         for (name, value) in get_test_specific_custom_urls(test_type, custom_dependency_urls)
             env_name = get_test_type_env_var_prefix(test_type) * name
-            _set_output_env_vars!(output_env_vars, env_name, value)
+            # do not use _set_output_env_vars!(), as this environment should be variable
+            # overridable
+            output_env_vars[env_name] = value
         end
     end
     return nothing


### PR DESCRIPTION
In PR #137 I implemented a function, which checks if a environment variable is already defined and does not overwrite it's value. But this behavior is not correct for each environment variable. For example the environment variable `CI_QED_ENABLE_CUDA_TESTS` should be overwritten if a specific label is set. This PR fix this.

Add also additional logger output. If `$(julia get_gitlab_ci_conf.jl)` is executed, it is not visible which environment variables are set. Therefore display this via info logger.