### PR TITLE
script to setup QED project with QED dev branch version dependencies

### DIFF
--- a/.ci/CI/script/setup_project.jl
+++ b/.ci/CI/script/setup_project.jl
@@ -1,0 +1,65 @@
+using ArgParse
+using CI
+using Pkg
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    s = ArgParseSettings("Script to setup and QED project with develop dependencies.")
+
+    @add_arg_table! s begin
+        "-d"
+        help = "Directory into which all repositories are cloned. Must exist."
+        arg_type = String
+        required = true
+        "-p"
+        help = "QED project to be setup."
+        arg_type = String
+        required = true
+    end
+
+    args = parse_args(s)
+    repo_prefix = args["d"]
+    project_name = args["p"]
+
+    # remove .jl from package name, if was set
+    if endswith(project_name, ".jl")
+        project_name = project_name[1:(end - 3)]
+    end
+
+    if !isdir(repo_prefix)
+        @error "$(repo_prefix) is not a directory."
+        exit(1)
+    end
+
+    compat_changes = Dict{String, String}()
+    pkg_tree = CI.build_qed_dependency_graph!(
+        repo_prefix,
+        compat_changes,
+        Dict{String, String}(),
+        project_name
+    )
+
+    project_path = joinpath(repo_prefix, project_name)
+    Pkg.activate(project_path)
+
+    pkg_ordering = CI.get_package_dependency_list(pkg_tree, "", project_name)
+    required_deps = CI.get_filtered_dependencies(r"^(QED*|QuantumElectrodynamics*)", Pkg.project().path)
+
+    linear_pkg_ordering = CI.calculate_linear_dependency_ordering(
+        pkg_ordering, required_deps
+    )
+
+    println(linear_pkg_ordering)
+
+    for stage in pkg_ordering[1:(end - 1)]
+
+    end
+    CI.remove_packages(linear_pkg_ordering, false)
+    CI.install_qed_dev_packages(
+        linear_pkg_ordering,
+        repo_prefix,
+        project_name,
+        project_path,
+        compat_changes,
+        false
+    )
+end

--- a/.ci/CI/src/modules/integ_test/graph.jl
+++ b/.ci/CI/src/modules/integ_test/graph.jl
@@ -104,6 +104,7 @@ Side effects of the function are:
     is checked out. The dict allows the use of custom URLs and branches for each QED project. The
     key is the package name and the value must have the following form: `<git_url>#<branch_name>`.
     The syntax is the same as for `Pkg.add()`.
+- `start_package_name::AbstractString`: Name of package which is the root of the dependency graph.
 
 # Returns
 
@@ -114,18 +115,19 @@ function build_qed_dependency_graph!(
         repository_base_path::AbstractString,
         compat_changes::Dict{String, String},
         custom_urls::Dict{String, String} = Dict{String, String}(),
+        start_package_name::AbstractString = "QuantumElectrodynamics"
     )::Dict
     @info "build QED dependency graph"
     io = IOBuffer()
     println(io, "input compat_changes: $(compat_changes)")
 
     qed_dependency_graph = Dict()
-    qed_dependency_graph["QuantumElectrodynamics"] = _build_qed_dependency_graph!(
+    qed_dependency_graph[start_package_name] = _build_qed_dependency_graph!(
         repository_base_path,
         compat_changes,
         custom_urls,
-        "QuantumElectrodynamics",
-        ["QuantumElectrodynamics"],
+        start_package_name,
+        [start_package_name],
     )
     println(io, "output compat_changes: $(compat_changes)")
     with_logger(debuglogger) do

--- a/.ci/CI/src/modules/setup_dev_env/dependency.jl
+++ b/.ci/CI/src/modules/setup_dev_env/dependency.jl
@@ -61,6 +61,8 @@ The algorithm works on a copy of the input graph.
 - `graph::Dict`: The dependency graph that is to be reduced
 - `stop_package::AbstractString=""`: If the stop package is found, stop the reduction before the
     graph is empty.
+- `start_package_name::AbstractString`: Name of package which is the root of the dependency graph.
+
 
 # Returns
 
@@ -69,9 +71,9 @@ e.g., pkg_ordering[1] stands for the first round. The set contains all the leave
 round. There is no order within a round.
 """
 function get_package_dependency_list(
-        graph::Dict, stop_package::AbstractString = ""
+        graph::Dict, stop_package::AbstractString = "", start_package_name::AbstractString = "QuantumElectrodynamics"
     )::Vector{Set{String}}
-    pkg_ordering = _get_package_dependency_list!(graph, stop_package)
+    pkg_ordering = _get_package_dependency_list!(graph, stop_package, start_package_name)
 
     with_logger(debuglogger) do
         io = IOBuffer()
@@ -86,14 +88,14 @@ function get_package_dependency_list(
 end
 
 function _get_package_dependency_list!(
-        graph::Dict, stop_package::AbstractString
+        graph::Dict, stop_package::AbstractString, start_package_name::AbstractString
     )::Vector{Set{String}}
     @info "calculate the correct sequence for adding QED packages"
     graph_copy = deepcopy(graph)
     pkg_ordering = Vector{Set{String}}()
     while true
-        if isempty(keys(graph_copy["QuantumElectrodynamics"]))
-            push!(pkg_ordering, Set{String}(["QuantumElectrodynamics"]))
+        if isempty(keys(graph_copy[start_package_name]))
+            push!(pkg_ordering, Set{String}([start_package_name]))
             return pkg_ordering
         end
         leafs = Set{String}()


### PR DESCRIPTION
# Usage

fix: #141 

```bash
cd .ci/CI
# clone repository of QEDFeynmanDiagrams and all it dependencies to repository_base
# checkout the dev branch version of all repositories
# set the other QED projects as develop dependency in QEDFeynmanDiagrams
julia --project=. script/setup_project.jl -d /repository_base -p QEDFeynmanDiagrams

```

# Notes

The script is a prototype. I think the script should 
- move to `QuantumElectrodynamics.jl` or
- be a function `QuantumElectrodynamics.jl` in the package or
- in an extra repo

Nevertheless, I think some of the functionality should be moved to https://github.com/QEDjl-project/IntegrationTests.jl