### PR TITLE
optimized  build_qed_dependency_graph!() for setup_dev_env.jl

### DIFF
--- a/.ci/CI/script/create_dev_env.jl
+++ b/.ci/CI/script/create_dev_env.jl
@@ -47,7 +47,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
             @info "Setup dev environment for package $(pkg)\n$(pkg_path)"
 
             required_deps = CI.get_filtered_dependencies(
-                r"^(QED*|QuantumElectrodynamics*)", joinpath(pkg_path, "Project.toml")
+                CI.get_qed_filter_regex(), joinpath(pkg_path, "Project.toml")
             )
             linear_pkg_ordering = CI.calculate_linear_dependency_ordering(
                 pkg_ordering, required_deps

--- a/.ci/CI/script/setup_dev_env.jl
+++ b/.ci/CI/script/setup_dev_env.jl
@@ -67,12 +67,12 @@ if abspath(PROGRAM_FILE) == @__FILE__
         qed_path = mktempdir(; cleanup = false)
 
         pkg_tree = CI.build_qed_dependency_graph!(
-            qed_path, compat_changes, test_specific_custom_urls
+            qed_path, compat_changes, test_specific_custom_urls, ENV["CI_QED_DEV_PKG_NAME"]
         )
-        pkg_ordering = CI.get_package_dependency_list(pkg_tree)
+        pkg_ordering = CI.get_package_dependency_list(pkg_tree, ENV["CI_QED_DEV_PKG_NAME"])
 
         required_deps = CI.get_filtered_dependencies(
-            r"^(QED*|QuantumElectrodynamics*)", active_project_project_toml
+            CI.get_qed_filter_regex(), active_project_project_toml
         )
 
         linear_pkg_ordering = CI.calculate_linear_dependency_ordering(
@@ -93,10 +93,10 @@ if abspath(PROGRAM_FILE) == @__FILE__
         )
     catch e
         # print debug information if uncatch error is thrown
-        println(String(take!(debug_logger_io)))
+        println(String(take!(CI.debug_logger_io)))
         throw(e)
     end
 
     # print debug information if debug information is manually enabled
-    @debug String(take!(debug_logger_io))
+    @debug String(take!(CI.debug_logger_io))
 end

--- a/.ci/CI/src/modules/integ_test/graph.jl
+++ b/.ci/CI/src/modules/integ_test/graph.jl
@@ -86,9 +86,9 @@ end
     )::Dict
 
 Creates the dependency graph of the QED package ecosystem just by parsing Projects.toml. The
-function starts by cloning the QuantumElectrodynamics.jl GitHub repository. Depending on
-QuantumElectrodynamics.jl `Project.toml`, clones all directly and indirectly dependent QED.jl
-GitHub repositories and constructs the dependency graph.
+function starts by cloning the `start_project`. Depending on `start_project` `Project.toml`, 
+clones all directly and indirectly dependent QED.jl GitHub repositories and constructs the 
+dependency graph.
 
 Side effects of the function are:
     - the Git repositories remain in the path defined in the `repository_base_path` variable
@@ -104,6 +104,8 @@ Side effects of the function are:
     is checked out. The dict allows the use of custom URLs and branches for each QED project. The
     key is the package name and the value must have the following form: `<git_url>#<branch_name>`.
     The syntax is the same as for `Pkg.add()`.
+- `start_project`: First package to be cloned. Only QED dependencies and their dependencies are 
+    used to build the graph.
 
 # Returns
 
@@ -114,18 +116,19 @@ function build_qed_dependency_graph!(
         repository_base_path::AbstractString,
         compat_changes::Dict{String, String},
         custom_urls::Dict{String, String} = Dict{String, String}(),
+        start_project::AbstractString = "QuantumElectrodynamics"
     )::Dict
     @info "build QED dependency graph"
     io = IOBuffer()
     println(io, "input compat_changes: $(compat_changes)")
 
     qed_dependency_graph = Dict()
-    qed_dependency_graph["QuantumElectrodynamics"] = _build_qed_dependency_graph!(
+    qed_dependency_graph[start_project] = _build_qed_dependency_graph!(
         repository_base_path,
         compat_changes,
         custom_urls,
-        "QuantumElectrodynamics",
-        ["QuantumElectrodynamics"],
+        start_project,
+        [start_project],
     )
     println(io, "output compat_changes: $(compat_changes)")
     with_logger(debuglogger) do

--- a/.ci/CI/src/modules/setup_dev_env/dependency.jl
+++ b/.ci/CI/src/modules/setup_dev_env/dependency.jl
@@ -1,4 +1,13 @@
 """
+    get_qed_filter_regex()::Regex
+
+Only packages which matches this regex will be used to construct the QED dependency graph.
+"""
+function get_qed_filter_regex()::Regex
+    return r"^(QED*|QuantumElectrodynamics*)"
+end
+
+"""
     get_filtered_dependencies(
         name_filter::Regex, project_toml_path::AbstractString
     )::AbstractVector{String}
@@ -61,6 +70,7 @@ The algorithm works on a copy of the input graph.
 - `graph::Dict`: The dependency graph that is to be reduced
 - `stop_package::AbstractString=""`: If the stop package is found, stop the reduction before the
     graph is empty.
+- `start_package`: Package name where the search begins.
 
 # Returns
 
@@ -69,9 +79,9 @@ e.g., pkg_ordering[1] stands for the first round. The set contains all the leave
 round. There is no order within a round.
 """
 function get_package_dependency_list(
-        graph::Dict, stop_package::AbstractString = ""
+        graph::Dict, start_packages::AbstractString = "QuantumElectrodynamics", stop_package::AbstractString = ""
     )::Vector{Set{String}}
-    pkg_ordering = _get_package_dependency_list!(graph, stop_package)
+    pkg_ordering = _get_package_dependency_list!(graph, start_packages, stop_package)
 
     with_logger(debuglogger) do
         io = IOBuffer()
@@ -86,14 +96,14 @@ function get_package_dependency_list(
 end
 
 function _get_package_dependency_list!(
-        graph::Dict, stop_package::AbstractString
+        graph::Dict, start_packages::AbstractString, stop_package::AbstractString
     )::Vector{Set{String}}
     @info "calculate the correct sequence for adding QED packages"
     graph_copy = deepcopy(graph)
     pkg_ordering = Vector{Set{String}}()
     while true
-        if isempty(keys(graph_copy["QuantumElectrodynamics"]))
-            push!(pkg_ordering, Set{String}(["QuantumElectrodynamics"]))
+        if isempty(keys(graph_copy[start_packages]))
+            push!(pkg_ordering, Set{String}([start_packages]))
             return pkg_ordering
         end
         leafs = Set{String}()

--- a/.ci/CI/test/setup_dev_env/get_package_dependency_list.jl
+++ b/.ci/CI/test/setup_dev_env/get_package_dependency_list.jl
@@ -36,7 +36,7 @@
         disable_info_logger_output() do
             original_graph = deepcopy(graph)
 
-            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "QuantumElectrodynamics")
 
             # verify that CI.get_package_dependency_list does not modify the graph
             @test original_graph == graph
@@ -57,7 +57,7 @@
 
     @testset "stop: QEDfields" begin
         disable_info_logger_output() do
-            pkg_ordering = CI.get_package_dependency_list(graph, "QEDfields")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "QEDfields")
 
             @test length(pkg_ordering) == 3
             @test pkg_ordering[1] == Set{String}(["QEDbase"])
@@ -68,7 +68,7 @@
 
     @testset "stop: QEDcore" begin
         disable_info_logger_output() do
-            pkg_ordering = CI.get_package_dependency_list(graph, "QEDcore")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "QEDcore")
 
             @test length(pkg_ordering) == 2
             @test pkg_ordering[1] == Set{String}(["QEDbase"])
@@ -78,7 +78,7 @@
 
     @testset "stop: QEDbase" begin
         disable_info_logger_output() do
-            pkg_ordering = CI.get_package_dependency_list(graph, "QEDbase")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "QEDbase")
 
             @test length(pkg_ordering) == 1
             @test pkg_ordering[1] == Set{String}(["QEDbase"])
@@ -87,7 +87,7 @@
 
     @testset "stop: NoStop" begin
         disable_info_logger_output() do
-            pkg_ordering = CI.get_package_dependency_list(graph, "NoStop")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "NoStop")
 
             @test length(pkg_ordering) == 4
             @test pkg_ordering[1] == Set{String}(["QEDbase"])
@@ -155,7 +155,7 @@ end
 
     @testset "stop: QuantumElectrodynamics" begin
         disable_info_logger_output() do
-            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "QuantumElectrodynamics")
 
             @test length(pkg_ordering) == 5
             @test pkg_ordering[1] == Set{String}(["QEDbase"])
@@ -175,7 +175,7 @@ end
 
     @testset "stop: QEDBigWhoop" begin
         disable_info_logger_output() do
-            pkg_ordering = CI.get_package_dependency_list(graph, "QEDBigWhoop")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "QEDBigWhoop")
 
             @test length(pkg_ordering) == 4
             @test pkg_ordering[1] == Set{String}(["QEDbase"])
@@ -194,7 +194,7 @@ end
 
     @testset "stop: QEDFeynmanDiagrams" begin
         disable_info_logger_output() do
-            pkg_ordering = CI.get_package_dependency_list(graph, "QEDFeynmanDiagrams")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "QEDFeynmanDiagrams")
 
             @test length(pkg_ordering) == 3
             @test pkg_ordering[1] == Set{String}(["QEDbase"])
@@ -205,7 +205,7 @@ end
 
     @testset "stop: QEDfields" begin
         disable_info_logger_output() do
-            pkg_ordering = CI.get_package_dependency_list(graph, "QEDfields")
+            pkg_ordering = CI.get_package_dependency_list(graph, "QuantumElectrodynamics", "QEDfields")
 
             @test length(pkg_ordering) == 3
             @test pkg_ordering[1] == Set{String}(["QEDbase"])


### PR DESCRIPTION
- Constructing the qed graph for setup_dev_env.jl does not start with cloning the QuantumElectrodynamics.jl anymore.
- Instead it uses the project where the dev environment should be setup is used as starting point.
- Nice side effect, setup_dev_env.jl also works with unregistered packages now.